### PR TITLE
Remove duplicate gke config sections from values.yaml

### DIFF
--- a/charts/terrakube/templates/gke/executor-backendconfig.yaml
+++ b/charts/terrakube/templates/gke/executor-backendconfig.yaml
@@ -7,9 +7,9 @@ metadata:
     {{- include "terrakube.labels" . | nindent 4 }}
 spec:
   timeoutSec: {{ .Values.ingress.gke.backendConfig.timeout }}
-  {{- if .Values.ingress.gke.backendConfig.securityPolicy }}
+  {{- if .Values.ingress.gke.backendConfig.executorSecurityPolicy }}
   securityPolicy:
-    name: {{ .Values.ingress.gke.backendConfig.securityPolicy }}
+    name: {{ .Values.ingress.gke.backendConfig.executorSecurityPolicy }}
   {{- end }}
   healthCheck:
     checkIntervalSec: 15

--- a/charts/terrakube/values.schema.json
+++ b/charts/terrakube/values.schema.json
@@ -750,7 +750,16 @@
                                 "create": {
                                     "type": "boolean"
                                 },
-                                "securityPolicy": {
+                                "apiSecurityPolicy": {
+                                    "type": "string"
+                                },
+                                "executorSecurityPolicy": {
+                                    "type": "string"
+                                },
+                                "registrySecurityPolicy": {
+                                    "type": "string"
+                                },
+                                "uiSecurityPolicy": {
                                     "type": "string"
                                 },
                                 "timeout": {
@@ -807,15 +816,6 @@
                             "type": "object",
                             "properties": {
                                 "create": {
-                                    "type": "boolean"
-                                },
-                                "domains": {
-                                    "type": "array"
-                                },
-                                "existingCertName": {
-                                    "type": "string"
-                                },
-                                "useExisting": {
                                     "type": "boolean"
                                 }
                             }

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -369,33 +369,6 @@ ingress:
   includeTlsHosts: true
   controller: "generic"  # Options: "generic", "aws", "gke, gatewayapi"
   
-  gke:
-    enabled: false
-    backendConfig:
-      create: false
-      timeout: 30
-      # Per-service security policies (optional)
-      uiSecurityPolicy: ""           # Cloud Armor policy for UI (user access restriction)
-      apiSecurityPolicy: ""          # Cloud Armor policy for API (usually empty - external access needed)
-      registrySecurityPolicy: ""     # Cloud Armor policy for Registry (usually empty - external access needed)
-      executorSecurityPolicy: ""     # Cloud Armor policy for Executor (usually empty if exposed)
-    managedCertificate:
-      create: false
-    frontendConfig:
-      create: false
-    externalDNS:
-      proxyEnabled: "false"
-      perIngressProxy:
-        ui: "false"
-        api: "false"
-        registry: "false"
-        executor: "false"
-    annotations: {}
-    uiStaticIPName: ""
-    apiStaticIPName: ""
-    registryStaticIPName: ""
-    executorStaticIPName: ""
-  
   aws:
     enabled: false
     certificateArn: ""
@@ -501,13 +474,14 @@ ingress:
     executorStaticIPName: ""
     managedCertificate:
       create: false
-      useExisting: false
-      existingCertName: ""
-      domains: []
     backendConfig:
       create: false
       timeout: 30
-      securityPolicy: "none"  # Cloud Armor security policy name (optional)
+      # Per-service security policies (optional)
+      uiSecurityPolicy: ""        # Cloud Armor policy for UI (user access restriction)
+      apiSecurityPolicy: ""       # Cloud Armor policy for API (usually empty - external access needed)
+      registrySecurityPolicy: ""  # Cloud Armor policy for Registry (usually empty - external access needed)
+      executorSecurityPolicy: ""  # Cloud Armor policy for Executor (usually empty if exposed)
     frontendConfig:
       create: false
       redirectToHttps: true


### PR DESCRIPTION
The GKE section is duplicated. This PR removes the first section which will anyway be overwritten by the second section. It also cleans up some unused GKE properties.