### PR TITLE
Remove GKE property proxyEnabled which has no effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,6 @@ Once you have completed the above steps you can complete the file values.yaml to
 | ingress.gke.backendConfig.registrySecurityPolicy | No       | Cloud Armor security policy for Registry service (usually empty)      |
 | ingress.gke.backendConfig.executorSecurityPolicy | No       | Cloud Armor security policy for Executor service (usually empty)      '
 | ingress.gke.frontendConfig.create         | No       | Create FrontendConfig resources (default: false)                      |
-| ingress.gke.externalDNS.proxyEnabled      | No       | Enable Cloudflare proxy for external-dns (default: "false")           |
 | ingress.gke.externalDNS.perIngressProxy   | No       | Per-service Cloudflare proxy settings                                 |
 | ingress.gke.annotations                   | No       | Global GKE annotations applied to all ingresses                       |
 | ingress.gke.uiStaticIPName                | No       | GCP static IP name for UI service                                      |

--- a/charts/terrakube/templates/ingress-api.yaml
+++ b/charts/terrakube/templates/ingress-api.yaml
@@ -103,12 +103,8 @@ metadata:
     {{- if .Values.ingress.gke.backendConfig.create }}
     cloud.google.com/backend-config: '{"ports": {"8080":"{{ .Values.name }}-api-backend-config", "5556":"{{ .Values.name }}-dex-backend-config"}}'
     {{- end }}
-    {{- if .Values.ingress.gke.externalDNS }}
-    {{- if .Values.ingress.gke.externalDNS.perIngressProxy }}
+    {{- if .Values.ingress.gke.externalDNS.perIngressProxy.api }}
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "{{ .Values.ingress.gke.externalDNS.perIngressProxy.api }}"
-    {{- else }}
-    external-dns.alpha.kubernetes.io/cloudflare-proxied: "{{ .Values.ingress.gke.externalDNS.proxyEnabled }}"
-    {{- end }}
     {{- end }}
     {{- range $key, $value := .Values.ingress.gke.annotations }}
     {{ $key }}: {{ tpl (toString $value) $ | quote }}

--- a/charts/terrakube/templates/ingress-executor.yaml
+++ b/charts/terrakube/templates/ingress-executor.yaml
@@ -85,12 +85,8 @@ metadata:
     {{- if .Values.ingress.gke.backendConfig.create }}
     cloud.google.com/backend-config: '{"default": "{{ .Values.name }}-executor-backend-config"}'
     {{- end }}
-    {{- if .Values.ingress.gke.externalDNS }}
-    {{- if .Values.ingress.gke.externalDNS.perIngressProxy }}
+    {{- if .Values.ingress.gke.externalDNS.perIngressProxy.executor }}
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "{{ .Values.ingress.gke.externalDNS.perIngressProxy.executor }}"
-    {{- else }}
-    external-dns.alpha.kubernetes.io/cloudflare-proxied: "{{ .Values.ingress.gke.externalDNS.proxyEnabled }}"
-    {{- end }}
     {{- end }}
     {{- range $key, $value := .Values.ingress.gke.annotations }}
     {{ $key }}: {{ tpl (toString $value) $ | quote }}

--- a/charts/terrakube/templates/ingress-registry.yaml
+++ b/charts/terrakube/templates/ingress-registry.yaml
@@ -85,12 +85,8 @@ metadata:
     {{- if .Values.ingress.gke.backendConfig.create }}
     cloud.google.com/backend-config: '{"default": "{{ .Values.name }}-registry-backend-config"}'
     {{- end }}
-    {{- if .Values.ingress.gke.externalDNS }}
-    {{- if .Values.ingress.gke.externalDNS.perIngressProxy }}
+    {{- if .Values.ingress.gke.externalDNS.perIngressProxy.registry }}
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "{{ .Values.ingress.gke.externalDNS.perIngressProxy.registry }}"
-    {{- else }}
-    external-dns.alpha.kubernetes.io/cloudflare-proxied: "{{ .Values.ingress.gke.externalDNS.proxyEnabled }}"
-    {{- end }}
     {{- end }}
     {{- range $key, $value := .Values.ingress.gke.annotations }}
     {{ $key }}: {{ tpl (toString $value) $ | quote }}

--- a/charts/terrakube/templates/ingress-ui.yaml
+++ b/charts/terrakube/templates/ingress-ui.yaml
@@ -85,12 +85,8 @@ metadata:
     {{- if .Values.ingress.gke.backendConfig.create }}
     cloud.google.com/backend-config: '{"default": "{{ .Values.name }}-ui-backend-config"}'
     {{- end }}
-    {{- if .Values.ingress.gke.externalDNS }}
-    {{- if .Values.ingress.gke.externalDNS.perIngressProxy }}
+    {{- if .Values.ingress.gke.externalDNS.perIngressProxy.ui }}
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "{{ .Values.ingress.gke.externalDNS.perIngressProxy.ui }}"
-    {{- else }}
-    external-dns.alpha.kubernetes.io/cloudflare-proxied: "{{ .Values.ingress.gke.externalDNS.proxyEnabled }}"
-    {{- end }}
     {{- end }}
     {{- range $key, $value := .Values.ingress.gke.annotations }}
     {{ $key }}: {{ tpl (toString $value) $ | quote }}

--- a/charts/terrakube/values.schema.json
+++ b/charts/terrakube/values.schema.json
@@ -786,9 +786,6 @@
                                             "type": "boolean"
                                         }
                                     }
-                                },
-                                "proxyEnabled": {
-                                    "type": "boolean"
                                 }
                             }
                         },

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -512,8 +512,7 @@ ingress:
       create: false
       redirectToHttps: true
     externalDNS:
-      proxyEnabled: false      # Control whether ExternalDNS creates proxy records (Cloudflare)
-      perIngressProxy:         # Optional: Allow per-ingress proxy settings
+      perIngressProxy:         # Control whether ExternalDNS creates proxy records (Cloudflare)
         ui: false
         api: false
         registry: false


### PR DESCRIPTION
The inner if statement (see diff) will always be true, so the else clause containing `proxyEnabled` will never come into play. This PR removes the effectively unused global toggle on the premise that it is likely that you will rarely want to "export" all the component services to Cloudflare.