### PR TITLE
Automatically mount additional certs provided via values

### DIFF
--- a/charts/terrakube/templates/deployment-api.yaml
+++ b/charts/terrakube/templates/deployment-api.yaml
@@ -48,14 +48,23 @@ spec:
         - name: metrics
           containerPort: {{ .Values.api.otel.metrics.port | default "9464" }}
         {{- end }}
-        {{- with .Values.api.env }}
         env:
+        {{- if .Values.security.caCerts }}
+        - name: SERVICE_BINDING_ROOT
+          value: /mnt/platform/bindings
+        {{- end }}
+        {{- with .Values.api.env }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         volumeMounts:
-          {{- with .Values.api.volumeMounts }}
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+        {{- if .Values.security.caCerts }}
+        - name: ca-certs
+          mountPath: /mnt/platform/bindings/ca-certificates
+          readOnly: true
+        {{- end }}
+        {{- with .Values.api.volumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         envFrom:
         {{- range .Values.api.secrets }}
         - secretRef:
@@ -100,8 +109,13 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.api.volumes }}
       volumes:
+      {{- if .Values.security.caCerts }}
+      - name: ca-certs
+        secret:
+          secretName: terrakube-ca-secrets
+      {{- end }}
+      {{- with .Values.api.volumes }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- with .Values.api.serviceAccountName }}

--- a/charts/terrakube/templates/deployment-executor.yaml
+++ b/charts/terrakube/templates/deployment-executor.yaml
@@ -48,14 +48,23 @@ spec:
         - name: metrics
           containerPort: {{ .Values.executor.otel.metrics.port | default "9464" }}
         {{- end }}
-        {{- with .Values.executor.env }}
         env:
+        {{- if .Values.security.caCerts }}
+        - name: SERVICE_BINDING_ROOT
+          value: /mnt/platform/bindings
+        {{- end }}
+        {{- with .Values.executor.env }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         volumeMounts:
-          {{- with .Values.executor.volumeMounts }}
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+        {{- if .Values.security.caCerts }}
+        - name: ca-certs
+          mountPath: /mnt/platform/bindings/ca-certificates
+          readOnly: true
+        {{- end }}
+        {{- with .Values.executor.volumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         envFrom:
         {{- range .Values.executor.secrets }}
         - secretRef:
@@ -99,8 +108,13 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.executor.volumes }}
       volumes:
+      {{- if .Values.security.caCerts }}
+      - name: ca-certs
+        secret:
+          secretName: terrakube-ca-secrets
+      {{- end }}
+      {{- with .Values.executor.volumes }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- with .Values.executor.serviceAccountName }}

--- a/charts/terrakube/templates/deployment-registry.yaml
+++ b/charts/terrakube/templates/deployment-registry.yaml
@@ -48,14 +48,23 @@ spec:
         - name: metrics
           containerPort: {{ .Values.registry.otel.metrics.port | default "9464" }}
         {{- end }}
-        {{- with .Values.registry.env }}
         env:
+        {{- if .Values.security.caCerts }}
+        - name: SERVICE_BINDING_ROOT
+          value: /mnt/platform/bindings
+        {{- end }}
+        {{- with .Values.registry.env }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         volumeMounts:
-          {{- with .Values.registry.volumeMounts }}
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+        {{- if .Values.security.caCerts }}
+        - name: ca-certs
+          mountPath: /mnt/platform/bindings/ca-certificates
+          readOnly: true
+        {{- end }}
+        {{- with .Values.registry.volumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         envFrom:
         {{- range .Values.registry.secrets }}
         - secretRef:
@@ -99,8 +108,13 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.registry.volumes }}
       volumes:
+      {{- if .Values.security.caCerts }}
+      - name: ca-certs
+        secret:
+          secretName: terrakube-ca-secrets
+      {{- end }}
+      {{- with .Values.registry.volumes }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- with .Values.registry.serviceAccountName }}


### PR DESCRIPTION
My main reason for automatically mount any ca certs passed via `security.caCerts` was to make the getting-started guide tighter, but a typical Terrakube is likely to need a local CA cert or two for other reasons, so this is probably a good simplification even for production installs.

Docs PR pending.