### PR TITLE
fix: Redis deployment hostname

### DIFF
--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.2.7
+version: 4.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/templates/secrets-api.yaml
+++ b/charts/terrakube/templates/secrets-api.yaml
@@ -24,7 +24,7 @@ stringData:
   DynamicCredentialPrivateKeyPath: '{{ .Values.api.dynamicCredentials.privateKeyPath }}'
   {{- if .Values.api.defaultRedis -}}
   #Default Redis
-  TerrakubeRedisHostname: 'terrakube-redis-master'
+  TerrakubeRedisHostname: '{{ .Values.name }}-redis-master'
   TerrakubeRedisPassword: {{ .Values.redis.auth.password }}
   {{ else }}
   #Custom Redis

--- a/charts/terrakube/templates/secrets-executor.yaml
+++ b/charts/terrakube/templates/secrets-executor.yaml
@@ -21,7 +21,7 @@ stringData:
   TerrakubeRedisPort: '{{ .Values.api.properties.redisPort }}'
   {{- if .Values.api.defaultRedis -}}
   #Default Redis
-  TerrakubeRedisHostname: 'terrakube-redis-master'
+  TerrakubeRedisHostname: '{{ .Values.name }}-redis-master'
   TerrakubeRedisPassword: '{{ .Values.redis.auth.password }}'
   {{ else }}
   #Custom Redis


### PR DESCRIPTION
This will allow to deploy terrakube using the following:

command:

```shell
helm install --values ./sample-values.yaml terrakube-dev ./charts/terrakube/ -n terrakube
```

helm values:

```yaml
name: "terrakube-dev"
.....
```


fix #225 