### PR TITLE
Simple option to enable ephemeral execution

### DIFF
--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.3.0
+version: 4.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/templates/deployment-api.yaml
+++ b/charts/terrakube/templates/deployment-api.yaml
@@ -49,6 +49,14 @@ spec:
           containerPort: {{ .Values.api.otel.metrics.port | default "9464" }}
         {{- end }}
         env:
+        {{- if .Values.api.ephemeralExecution.enabled }}
+        - name: ExecutorEphemeralNamespace
+          value: {{ .Release.Namespace }}
+        - name: ExecutorEphemeralImage
+          value: {{ .Values.executor.image }}:{{ default .Chart.AppVersion .Values.executor.version }}
+        - name: ExecutorEphemeralSecret
+          value: {{ .Values.api.ephemeralExecution.secretName }}
+        {{- end }}
         {{- if .Values.security.caCerts }}
         - name: SERVICE_BINDING_ROOT
           value: /mnt/platform/bindings

--- a/charts/terrakube/templates/rbac-api.yaml
+++ b/charts/terrakube/templates/rbac-api.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.api.rbac.create -}}
+{{- if (or .Values.api.rbac.create .Values.api.ephemeralExecution.enabled) -}}
+{{- $_ := required "Must set .Values.api.serviceAccountName" .Values.api.serviceAccountName }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/terrakube/values.schema.json
+++ b/charts/terrakube/values.schema.json
@@ -157,6 +157,17 @@
                         }
                     }
                 },
+                "ephemeralExecution": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "secretName": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "readinessProbe": {
                     "type": "object",
                     "properties": {

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -217,6 +217,9 @@ api:
     create: false
     roleName: "terrakube-api-role"
     roleBindingName: "terrakube-api-role-binding"
+  ephemeralExecution:
+    enabled: false
+    secretName: terrakube-executor-secrets
   secrets:
    - terrakube-api-secrets
   resources: {}


### PR DESCRIPTION
This PR reduces the setup for the baseline case of https://docs.terrakube.io/getting-started/deployment/ephemeral-agents to `api.ephemeralExecution.enable=true`.

It is a bit unfortunate that `api.serviceAccountName` is set to blank by default, but changing that would break backwards compatibility since users may have started their Terrakube journey with a `helm show values terrakube-repo/terrakube > my-values.yaml`. It would have been nice to convert the default to
```yaml
api:
  serviceAccount:
    create: false
    name: terrakube-api
```
but alas, we have to make do with a `require` guard.

Fixes #208.