### PR TITLE
Improved probes for faster startup time

### DIFF
--- a/charts/terrakube/templates/deployment-api.yaml
+++ b/charts/terrakube/templates/deployment-api.yaml
@@ -76,22 +76,19 @@ spec:
         {{- end }}
         startupProbe:
           httpGet:
-            path: /actuator/health
+            path: /actuator/health/readiness
             port: 8080
-          initialDelaySeconds: 30  # Increased from default
-          periodSeconds: 10
-          failureThreshold: 30     # Increased to give more startup time
+          periodSeconds: {{ .Values.api.startupProbe.periodSeconds }}
+          failureThreshold: {{ .Values.api.startupProbe.failureThreshold }}
         livenessProbe:
           httpGet:
             path: /actuator/health/liveness
             port: http
-          initialDelaySeconds: {{ .Values.api.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.api.livenessProbe.periodSeconds }}
         readinessProbe:
           httpGet:
             path: /actuator/health/readiness
             port: http
-          initialDelaySeconds: {{ .Values.api.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.api.readinessProbe.periodSeconds }}
         {{- with .Values.api.containerSecurityContext }}
         securityContext:

--- a/charts/terrakube/templates/deployment-executor.yaml
+++ b/charts/terrakube/templates/deployment-executor.yaml
@@ -76,7 +76,7 @@ spec:
         {{- end }}
         startupProbe:
           httpGet:
-            path: /actuator/health
+            path: /actuator/health/readiness
             port: 8090
           failureThreshold: {{ .Values.executor.startupProbe.failureThreshold }}
           periodSeconds: {{ .Values.executor.startupProbe.periodSeconds }}
@@ -84,13 +84,11 @@ spec:
           httpGet:
             path: /actuator/health/liveness
             port: 8090
-          initialDelaySeconds: {{ .Values.executor.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.executor.livenessProbe.periodSeconds }}
         readinessProbe:
           httpGet:
             path: /actuator/health/readiness
             port: 8090
-          initialDelaySeconds: {{ .Values.executor.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.executor.readinessProbe.periodSeconds }}
         {{- with .Values.executor.containerSecurityContext }}
         securityContext:

--- a/charts/terrakube/templates/deployment-registry.yaml
+++ b/charts/terrakube/templates/deployment-registry.yaml
@@ -84,13 +84,11 @@ spec:
           httpGet:
             path: /actuator/health/liveness
             port: 8075
-          initialDelaySeconds: {{ .Values.registry.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.registry.livenessProbe.periodSeconds }}
         readinessProbe:
           httpGet:
             path: /actuator/health/readiness
             port: 8075
-          initialDelaySeconds: {{ .Values.registry.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.registry.readinessProbe.periodSeconds }}
         {{- with .Values.registry.containerSecurityContext }}
         securityContext:

--- a/charts/terrakube/values.schema.json
+++ b/charts/terrakube/values.schema.json
@@ -55,9 +55,6 @@
                 "livenessProbe": {
                     "type": "object",
                     "properties": {
-                        "initialDelaySeconds": {
-                            "type": "integer"
-                        },
                         "periodSeconds": {
                             "type": "integer"
                         }
@@ -160,9 +157,6 @@
                 "readinessProbe": {
                     "type": "object",
                     "properties": {
-                        "initialDelaySeconds": {
-                            "type": "integer"
-                        },
                         "periodSeconds": {
                             "type": "integer"
                         }
@@ -460,9 +454,6 @@
                 "livenessProbe": {
                     "type": "object",
                     "properties": {
-                        "initialDelaySeconds": {
-                            "type": "integer"
-                        },
                         "periodSeconds": {
                             "type": "integer"
                         }
@@ -518,9 +509,6 @@
                 "readinessProbe": {
                     "type": "object",
                     "properties": {
-                        "initialDelaySeconds": {
-                            "type": "integer"
-                        },
                         "periodSeconds": {
                             "type": "integer"
                         }

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -233,12 +233,10 @@ api:
   initContainers: []
   startupProbe:
     failureThreshold: 30
-    periodSeconds: 10
+    periodSeconds: 5
   readinessProbe:
-    initialDelaySeconds: 120
     periodSeconds: 10
   livenessProbe:
-    initialDelaySeconds: 10
     periodSeconds: 10
   cache:
     moduleCacheMaxTotal: "128"
@@ -298,12 +296,10 @@ executor:
   initContainers: []
   startupProbe:
     failureThreshold: 30
-    periodSeconds: 10
+    periodSeconds: 5
   readinessProbe:
-    initialDelaySeconds: 120
     periodSeconds: 10
   livenessProbe:
-    initialDelaySeconds: 10
     periodSeconds: 10
 
 ## Registry properties
@@ -337,12 +333,10 @@ registry:
   initContainers: []
   startupProbe:
     failureThreshold: 30
-    periodSeconds: 10
+    periodSeconds: 5
   readinessProbe:
-    initialDelaySeconds: 120
     periodSeconds: 10
   livenessProbe:
-    initialDelaySeconds: 10
     periodSeconds: 10
 
 ## UI Properties


### PR DESCRIPTION
The primary thing here is to remove the initialDelaySeconds on readiness and liveness; since we have a startup probe, these serve no purpoes. Also, we switch the startup probe to look for readiness so that the service is known to be ready on startup (unlike the readiness probe, startup probe will kill the pod).

Primarily because of the long `initialDelaySeconds` on readiness check, it took almost 3 minutes to roll over e.g. `terrakube-api` deployment. With this change, it takes about 30 seconds. This time becomes significant if we scale the service to several replicas.