### PR TITLE
feat: Support GitHub App Tokens For Private Extensions

### DIFF
--- a/charts/terrakube/templates/secrets-api.yaml
+++ b/charts/terrakube/templates/secrets-api.yaml
@@ -14,6 +14,8 @@ stringData:
   InternalSecret: '{{ .Values.security.internalSecret | b64enc }}'
   DexIssuerUri: '{{ .Values.dex.config.issuer }}'
   DexClientId: '{{ .Values.security.dexClientId }}'
+  TerrakubeToolsRepository: '{{ .Values.executor.properties.toolsRepository }}'
+  TerrakubeToolsBranch: '{{ .Values.executor.properties.toolsBranch }}'
   TerrakubeHostname: '{{ .Values.ingress.api.domain }}'
   AzBuilderExecutorUrl: '{{ .Values.api.properties.executorUrl }}/api/v1/terraform-rs'
   ExecutorReplicas: '{{ .Values.api.properties.executorReplicaCount |  default .Values.executor.replicaCount }}'


### PR DESCRIPTION
## Problem

terrakube-io/terrakube#2737 requires the API pod to receive `TerrakubeToolsRepository` and `TerrakubeToolsBranch` so it can request GitHub App installation tokens for private extensions.  
Helm chart currently provides these env vars **only** to the executor, so any Helm-based deployment leaves the API without the tools repo configuration and GitHub App flows still fail.

## Solution

- In `charts/api/templates/secrets-api.yaml` add:
  ```yaml
  TerrakubeToolsRepository: {{ .Values.executor.properties.toolsRepository | quote }}
  TerrakubeToolsBranch: {{ .Values.executor.properties.toolsBranch | quote }}
 
 ## Related PRs

- Companion Terrakube changes: terrakube-io/terrakube#2737