### PR TITLE
feat: allow gateway api version customisation

### DIFF
--- a/charts/terrakube/templates/httproute-api.yaml
+++ b/charts/terrakube/templates/httproute-api.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.ingress.api.enabled (eq .Values.ingress.controller "gatewayapi") }}
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/{{ .Values.ingress.gatewayapi.apiVersion }}
 kind: HTTPRoute
 metadata:
   name: {{ .Values.name }}-api

--- a/charts/terrakube/templates/httproute-executor.yaml
+++ b/charts/terrakube/templates/httproute-executor.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.ingress.executor.enabled (eq .Values.ingress.controller "gatewayapi") }}
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/{{ .Values.ingress.gatewayapi.apiVersion }}
 kind: HTTPRoute
 metadata:
   name: {{ .Values.name }}-executor

--- a/charts/terrakube/templates/httproute-registry.yaml
+++ b/charts/terrakube/templates/httproute-registry.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.ingress.registry.enabled (eq .Values.ingress.controller "gatewayapi") }}
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/{{ .Values.ingress.gatewayapi.apiVersion }}
 kind: HTTPRoute
 metadata:
   name: {{ .Values.name }}-registry

--- a/charts/terrakube/templates/httproute-ui.yaml
+++ b/charts/terrakube/templates/httproute-ui.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.ingress.ui.enabled (eq .Values.ingress.controller "gatewayapi") }}
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/{{ .Values.ingress.gatewayapi.apiVersion }}
 kind: HTTPRoute
 metadata:
   name: {{ .Values.name }}-ui

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -368,6 +368,7 @@ ingress:
   controller: "generic"  # Options: "generic", "aws", "gke, gatewayapi"
 
   gatewayapi:
+    apiVersion: v1beta1
     enabled: false
     gateways: []
     annotations: {}


### PR DESCRIPTION
Hi there

I have a problem with the stock charts - I cannot deploy them to my cluster as I'm running Gateway API v1 there. When you deploy v1beta1 resources they are accepted by the API server but not actioned by the controller.

I've made it work on this branch, you can customise the API version by setting `ingress.gatewayapi.apiVersion="v1"` when templating the chart. The default behaviour is to template using the current version `v1beta1`.

Thanks