### PR TITLE
fix: move skipApprovalScreen under oauth2

### DIFF
--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -46,9 +46,9 @@ dex:
     web:
       http: 0.0.0.0:5556
       allowedOrigins: ['*']
-      skipApprovalScreen: true
     oauth2:
       responseTypes: ["code", "token", "id_token"]
+      skipApprovalScreen: true
 
     connectors:
     - type: ldap


### PR DESCRIPTION
In many examples, this option is in the correct place under oauth2. It was still under wrong section in `values.yaml`

Fixes: #247