### PR TITLE
feat: Make AWS S3 access and secret keys optional in storage secrets configuration across API, executor, and registry components.

### DIFF
--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.5.4
+version: 4.5.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,22 +24,22 @@ version: 4.5.4
 appVersion: "2.29.0"
 
 dependencies:
-- name: minio
-  version: "17.0.21"
-  condition: storage.defaultStorage
-  repository: "https://charts.bitnami.com/bitnami"
+  - name: minio
+    version: "17.0.21"
+    condition: storage.defaultStorage
+    repository: "https://charts.bitnami.com/bitnami"
 
-- name: postgresql
-  version: "16.7.27"
-  condition: api.defaultDatabase
-  repository: "https://charts.bitnami.com/bitnami"
+  - name: postgresql
+    version: "16.7.27"
+    condition: api.defaultDatabase
+    repository: "https://charts.bitnami.com/bitnami"
 
-- name: dex
-  version: "0.24.0"
-  condition: dex.enabled
-  repository: "https://charts.dexidp.io"
+  - name: dex
+    version: "0.24.0"
+    condition: dex.enabled
+    repository: "https://charts.dexidp.io"
 
-- name: redis
-  version: "22.0.7"
-  condition: api.defaultRedis
-  repository: "https://charts.bitnami.com/bitnami"
+  - name: redis
+    version: "22.0.7"
+    condition: api.defaultRedis
+    repository: "https://charts.bitnami.com/bitnami"

--- a/charts/terrakube/templates/secrets-api.yaml
+++ b/charts/terrakube/templates/secrets-api.yaml
@@ -53,11 +53,13 @@ stringData:
   AzureAccountKey: '{{ .Values.storage.azure.storageAccountAccessKey }}'
   {{- end }}
   
-  {{- if and (.Values.storage.aws).bucketName (.Values.storage.aws).accessKey (.Values.storage.aws).secretKey (.Values.storage.aws).region  }}
+  {{- if and (.Values.storage.aws).bucketName (.Values.storage.aws).region  }}
   #AWS S3 Storage
   StorageType: 'AWS'
+  {{- if and (.Values.storage.aws).accessKey (.Values.storage.aws).secretKey }}
   AwsStorageAccessKey: '{{ .Values.storage.aws.accessKey }}'
   AwsStorageSecretKey: '{{ .Values.storage.aws.secretKey }}'
+  {{- end }}
   AwsStorageBucketName: '{{ .Values.storage.aws.bucketName }}'
   AwsStorageRegion: '{{ .Values.storage.aws.region }}'
   AwsEndpoint: ''

--- a/charts/terrakube/templates/secrets-executor.yaml
+++ b/charts/terrakube/templates/secrets-executor.yaml
@@ -59,16 +59,20 @@ stringData:
   AzureTerraformOutputAccountKey: '{{ .Values.storage.azure.storageAccountAccessKey }}'
   {{- end }}
   
-  {{- if and (.Values.storage.aws).bucketName (.Values.storage.aws).accessKey (.Values.storage.aws).secretKey (.Values.storage.aws).region  }}
+  {{- if and (.Values.storage.aws).bucketName (.Values.storage.aws).region  }}
   #AWS S3 Storage
   TerraformStateType: 'AwsTerraformStateImpl'
+  {{- if and (.Values.storage.aws).accessKey (.Values.storage.aws).secretKey }}
   AwsTerraformStateAccessKey: '{{ .Values.storage.aws.accessKey }}'
   AwsTerraformStateSecretKey: '{{ .Values.storage.aws.secretKey }}'
+  {{- end }}
   AwsTerraformStateBucketName: '{{ .Values.storage.aws.bucketName }}'
   AwsTerraformStateRegion: '{{ .Values.storage.aws.region }}'
   TerraformOutputType: 'AwsTerraformOutputImpl'
+  {{- if and (.Values.storage.aws).accessKey (.Values.storage.aws).secretKey }}
   AwsTerraformOutputAccessKey: '{{ .Values.storage.aws.accessKey }}'
   AwsTerraformOutputSecretKey: '{{ .Values.storage.aws.secretKey }}'
+  {{- end }}
   AwsTerraformOutputBucketName: '{{ .Values.storage.aws.bucketName }}'
   AwsTerraformOutputRegion: '{{ .Values.storage.aws.region }}'
   AwsEndpoint: ''

--- a/charts/terrakube/templates/secrets-registry.yaml
+++ b/charts/terrakube/templates/secrets-registry.yaml
@@ -38,11 +38,13 @@ stringData:
   AzureAccountKey: '{{ .Values.storage.azure.storageAccountAccessKey }}'
   {{- end }}
   
-  {{- if and (.Values.storage.aws).bucketName (.Values.storage.aws).accessKey (.Values.storage.aws).secretKey (.Values.storage.aws).region  }}
+  {{- if and (.Values.storage.aws).bucketName (.Values.storage.aws).region  }}
   #Aws Storage
   RegistryStorageType: 'AwsStorageImpl'
+  {{- if and (.Values.storage.aws).accessKey (.Values.storage.aws).secretKey }}
   AwsStorageAccessKey: '{{ .Values.storage.aws.accessKey }}'
   AwsStorageSecretKey: '{{ .Values.storage.aws.secretKey }}'
+  {{- end }}
   AwsStorageBucketName: '{{ .Values.storage.aws.bucketName }}'
   AwsStorageRegion: '{{ .Values.storage.aws.region }}'
   AwsEndpoint: ''


### PR DESCRIPTION
Hi @alfespa17, @jcanizalez,

This PR makes the AWS `accessKey` and `secretKey` fields optional when configuring AWS storage in the Helm chart secrets (registry, executor, and api).

Currently, when using IAM Roles for Service Accounts (IRSA) or an EC2 Instance Profile on AWS, we still are required to set dummy values for `accessKey` and `secretKey` in the values.yaml file so the storage configuration is applied. While setting invalid strings works as a workaround, it is counterintuitive since the credentials are not actually needed and are securely provided by the AWS environment.

This change ensures a cleaner configuration process for those utilizing IAM roles, eliminating the need to populate unnecessary placeholder secrets.