### PR TITLE
feat: split non-sensitive configuration from Secret into ConfigMap

### DIFF
--- a/charts/terrakube/templates/configMap-api.yaml
+++ b/charts/terrakube/templates/configMap-api.yaml
@@ -1,0 +1,104 @@
+{{- if .Values.api.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: terrakube-api-config
+  labels:
+    {{- include "terrakube.labels" . | nindent 4 }}
+data:
+  GroupValidationType: 'DEX'
+  UserValidationType: 'DEX'
+  AuthenticationValidationType: 'DEX'
+  DexIssuerUri: '{{ .Values.dex.config.issuer }}'
+  TerrakubeToolsRepository: '{{ .Values.executor.properties.toolsRepository }}'
+  TerrakubeToolsBranch: '{{ .Values.executor.properties.toolsBranch }}'
+  TerrakubeHostname: '{{ .Values.ingress.api.domain }}'
+  AzBuilderExecutorUrl: '{{ .Values.api.properties.executorUrl }}/api/v1/terraform-rs'
+  ExecutorReplicas: '{{ .Values.api.properties.executorReplicaCount |  default .Values.executor.replicaCount }}'
+  TerrakubeUiURL: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.ui.domain }}'
+  TERRAKUBE_ADMIN_GROUP: '{{ .Values.security.adminGroup }}'
+  TerrakubeRedisPort: '{{ .Values.api.properties.redisPort }}'
+  DynamicCredentialPublicKeyPath: '{{ .Values.api.dynamicCredentials.publicKeyPath }}'
+  DynamicCredentialPrivateKeyPath: '{{ .Values.api.dynamicCredentials.privateKeyPath }}'
+  {{- if .Values.api.defaultRedis }}
+  #Default Redis
+  TerrakubeRedisHostname: '{{ .Release.Name }}-redis-master'
+  {{- else }}
+  #Custom Redis
+  TerrakubeRedisHostname: '{{ .Values.api.properties.redisHostname }}'
+  {{- end }}
+
+  {{- if .Values.storage.defaultStorage }}
+
+  #AWS S3 Storage
+  StorageType: 'AWS'
+  AwsStorageBucketName: '{{ .Values.minio.defaultBuckets }}'
+  AwsStorageRegion: '{{ .Values.storage.default.region }}'
+  AwsEndpoint: {{ .Values.storage.default.endpoint | default (printf "http://%s-minio:9000" .Release.Name) | quote }}
+
+  {{- else }}
+
+  {{- if and (.Values.storage.azure).storageAccountName (.Values.storage.azure).storageAccountAccessKey }}
+  #Azure Storage
+  StorageType: 'AZURE'
+  AzureAccountName: '{{ .Values.storage.azure.storageAccountName }}'
+  {{- end }}
+
+  {{- if and (.Values.storage.aws).bucketName (.Values.storage.aws).region }}
+  #AWS S3 Storage
+  StorageType: 'AWS'
+  AwsStorageBucketName: '{{ .Values.storage.aws.bucketName }}'
+  AwsStorageRegion: '{{ .Values.storage.aws.region }}'
+  AwsEndpoint: ''
+  {{- end }}
+
+  {{- if and (.Values.storage.minio).bucketName (.Values.storage.minio).accessKey (.Values.storage.minio).secretKey (.Values.storage.minio).endpoint }}
+  #MINIO S3 Storage
+  StorageType: 'AWS'
+  AwsStorageBucketName: '{{ .Values.storage.minio.bucketName }}'
+  AwsStorageRegion: 'us-east-1' # THIS IS NEEDED IN ORDER TO CONNECT TO MINIO USING THE AWS CODE, HARD CODED IT HAS NO EFFECT
+  AwsEndpoint: '{{ .Values.storage.minio.endpoint }}'
+  {{- end }}
+
+  {{- if and (.Values.storage.gcp).projectId (.Values.storage.gcp).bucketName (.Values.storage.gcp).credentials }}
+  #GCP Storage Bucket
+  StorageType: 'GCP'
+  GcpStorageProjectId: '{{ .Values.storage.gcp.projectId }}'
+  GcpStorageBucketName: '{{ .Values.storage.gcp.bucketName }}'
+  {{- end }}
+
+  {{- end }}
+
+  {{- if .Values.api.defaultDatabase }}
+  #Checking default database options
+  DatasourceHostname: '{{ .Release.Name }}-postgresql'
+  DatasourceDatabase: '{{ .Values.postgresql.auth.database }}'
+  DatasourceUser: '{{ .Values.postgresql.auth.username}}'
+  DatasourcePort: '5432'
+  ApiDataSourceType: 'POSTGRESQL'
+  DatasourceSchema: '{{ .Values.api.properties.databaseSchema }}'
+  DatasourceSslMode: '{{ .Values.api.properties.databaseSslMode }}'
+  {{- else }}
+  ApiDataSourceType: '{{ .Values.api.properties.databaseType }}'
+  DatasourceHostname: '{{ .Values.api.properties.databaseHostname }}'
+  DatasourceDatabase: '{{ .Values.api.properties.databaseName }}'
+  DatasourceUser: '{{ .Values.api.properties.databaseUser }}'
+  DatasourceSslMode: '{{ .Values.api.properties.databaseSslMode }}'
+  DatasourcePort: '{{ .Values.api.properties.databasePort }}'
+  DatasourceSchema: '{{ .Values.api.properties.databaseSchema }}'
+  {{- end }}
+
+  {{- if .Values.api.loadSampleData }}
+  #Checking if we need to load the default data for testing
+  spring_profiles_active: 'demo'
+  {{- end }}
+
+  #Custom terraform releases url
+  CustomTerraformReleasesUrl : '{{ .Values.api.terraformReleasesUrl }}'
+  CustomTofuReleasesUrl : '{{ .Values.api.tofuReleasesUrl }}'
+  ModuleCacheMaxTotal: '{{ .Values.api.cache.moduleCacheMaxTotal }}'
+  ModuleCacheMaxIdle: '{{ .Values.api.cache.moduleCacheMaxIdle }}'
+  ModuleCacheMinIdle: '{{ .Values.api.cache.moduleCacheMinIdle }}'
+  ModuleCacheTimeout: '{{ .Values.api.cache.moduleCacheTimeout }}'
+  ModuleCacheSchedule: '{{ .Values.api.cache.moduleCacheSchedule }}'
+{{ end }}

--- a/charts/terrakube/templates/configMap-executor.yaml
+++ b/charts/terrakube/templates/configMap-executor.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.executor.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: terrakube-executor-config
+  labels:
+    {{- include "terrakube.labels" . | nindent 4 }}
+data:
+  # General Settings
+  AzBuilderApiUrl: '{{ .Values.executor.apiServiceUrl }}'
+  ExecutorFlagBatch: 'false'
+  ExecutorFlagDisableAcknowledge: 'false'
+  TerrakubeToolsRepository: '{{ .Values.executor.properties.toolsRepository }}'
+  TerrakubeToolsBranch: '{{ .Values.executor.properties.toolsBranch }}'
+  TerrakubeEnableSecurity: 'true'
+  TerrakubeRegistryDomain: '{{ .Values.ingress.registry.domain }}'
+  TerrakubeApiUrl: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.api.domain }}'
+  TerrakubeRedisPort: '{{ .Values.api.properties.redisPort }}'
+  {{- if .Values.api.defaultRedis }}
+  #Default Redis
+  TerrakubeRedisHostname: '{{ .Release.Name }}-redis-master'
+  {{- else }}
+  #Custom Redis
+  TerrakubeRedisHostname: '{{ .Values.api.properties.redisHostname }}'
+  {{- end }}
+
+  {{- if .Values.storage.defaultStorage }}
+
+  #AWS S3 Storage using MINIO
+  TerraformStateType: 'AwsTerraformStateImpl'
+  AwsTerraformStateBucketName: '{{ .Values.minio.defaultBuckets }}'
+  AwsTerraformStateRegion: '{{ .Values.storage.default.region }}'
+  TerraformOutputType: 'AwsTerraformOutputImpl'
+  AwsTerraformOutputBucketName: '{{ .Values.minio.defaultBuckets }}'
+  AwsTerraformOutputRegion: '{{ .Values.storage.default.region }}'
+  AwsEndpoint: {{ .Values.storage.default.endpoint | default (printf "http://%s-minio:9000" .Release.Name) | quote }}
+
+  {{- else }}
+
+  {{- if and (.Values.storage.azure).storageAccountName (.Values.storage.azure).storageAccountAccessKey }}
+  #Azure Storage
+  TerraformStateType: 'AzureTerraformStateImpl'
+  AzureTerraformStateResourceGroup: '{{ .Values.storage.azure.storageAccountResourceGroup }}'
+  AzureTerraformStateStorageAccountName: '{{ .Values.storage.azure.storageAccountName }}'
+  AzureTerraformStateStorageContainerName: 'tfstate'
+  TerraformOutputType: 'AzureTerraformOutputImpl'
+  AzureTerraformOutputAccountName: '{{ .Values.storage.azure.storageAccountName }}'
+  {{- end }}
+
+  {{- if and (.Values.storage.aws).bucketName (.Values.storage.aws).region }}
+  #AWS S3 Storage
+  TerraformStateType: 'AwsTerraformStateImpl'
+  AwsTerraformStateBucketName: '{{ .Values.storage.aws.bucketName }}'
+  AwsTerraformStateRegion: '{{ .Values.storage.aws.region }}'
+  TerraformOutputType: 'AwsTerraformOutputImpl'
+  AwsTerraformOutputBucketName: '{{ .Values.storage.aws.bucketName }}'
+  AwsTerraformOutputRegion: '{{ .Values.storage.aws.region }}'
+  AwsEndpoint: ''
+  {{- end }}
+
+  {{- if and (.Values.storage.minio).bucketName (.Values.storage.minio).accessKey (.Values.storage.minio).secretKey (.Values.storage.minio).endpoint }}
+  #MINIO S3 Storage
+  TerraformStateType: 'AwsTerraformStateImpl' # MINIO USES THE AWS LIBRARY
+  AwsTerraformStateBucketName: '{{ .Values.storage.minio.bucketName }}'
+  AwsTerraformStateRegion: 'us-east-1' # THIS IS NEEDED IN ORDER TO CONNECT TO MINIO USING THE AWS CODE, HARD CODED IT HAS NO EFFECT
+  TerraformOutputType: 'AwsTerraformOutputImpl' # MINIO USES THE AWS LIBRARY
+  AwsTerraformOutputBucketName: '{{ .Values.storage.minio.bucketName }}'
+  AwsTerraformOutputRegion: 'us-east-1' # THIS IS NEEDED IN ORDER TO CONNECT TO MINIO USING THE AWS CODE, HARD CODED IT HAS NO EFFECT
+  AwsEndpoint: '{{ .Values.storage.minio.endpoint }}'
+  {{- end }}
+
+  {{- if and (.Values.storage.gcp).projectId (.Values.storage.gcp).bucketName (.Values.storage.gcp).credentials }}
+  #GCP Storage Bucket
+  TerraformStateType: 'GcpTerraformStateImpl'
+  GcpTerraformStateProjectId: '{{ .Values.storage.gcp.projectId }}'
+  GcpTerraformStateBucketName: '{{ .Values.storage.gcp.bucketName }}'
+  TerraformOutputType: 'GcpTerraformOutputImpl'
+  GcpTerraformOutputProjectId: '{{ .Values.storage.gcp.projectId }}'
+  GcpTerraformOutputBucketName: '{{ .Values.storage.gcp.bucketName }}'
+  {{- end }}
+
+  {{- end }}
+
+  #Custom terraform releases url
+  CustomTerraformReleasesUrl : '{{ .Values.api.terraformReleasesUrl }}'
+
+{{ end }}

--- a/charts/terrakube/templates/configMap-registry.yaml
+++ b/charts/terrakube/templates/configMap-registry.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.registry.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: terrakube-registry-config
+  labels:
+    {{- include "terrakube.labels" . | nindent 4 }}
+data:
+  AzBuilderRegistry: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.registry.domain }}'
+  AzBuilderApiUrl: 'http://terrakube-api-service:8080'
+  AuthenticationValidationTypeRegistry: 'DEX'
+  DexIssuerUri: '{{ .Values.dex.config.issuer }}'
+  TerrakubeEnableSecurity: 'true'
+  TerrakubeUiURL: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.ui.domain }}'
+  AppIssuerUri: '{{ .Values.dex.config.issuer }}'
+
+  {{- if .Values.storage.defaultStorage }}
+
+  #AWS S3 Storage using MINIO
+  RegistryStorageType: 'AwsStorageImpl'
+  AwsStorageBucketName: '{{ .Values.minio.defaultBuckets }}'
+  AwsStorageRegion: '{{ .Values.storage.default.region }}'
+  AwsEndpoint: {{ .Values.storage.default.endpoint | default (printf "http://%s-minio:9000" .Release.Name) | quote }}
+
+  {{- else }}
+
+  {{- if and (.Values.storage.azure).storageAccountName (.Values.storage.azure).storageAccountAccessKey }}
+  #Azure Storage
+  RegistryStorageType: 'AzureStorageImpl'
+  AzureAccountName: '{{ .Values.storage.azure.storageAccountName }}'
+  {{- end }}
+
+  {{- if and (.Values.storage.aws).bucketName (.Values.storage.aws).region }}
+  #Aws Storage
+  RegistryStorageType: 'AwsStorageImpl'
+  AwsStorageBucketName: '{{ .Values.storage.aws.bucketName }}'
+  AwsStorageRegion: '{{ .Values.storage.aws.region }}'
+  AwsEndpoint: ''
+  {{- end }}
+
+  {{- if and (.Values.storage.minio).bucketName (.Values.storage.minio).accessKey (.Values.storage.minio).secretKey (.Values.storage.minio).endpoint }}
+  #MINIO Storage
+  RegistryStorageType: 'AwsStorageImpl'
+  AwsStorageBucketName: '{{ .Values.storage.minio.bucketName }}'
+  AwsStorageRegion: 'us-east-1' # THIS IS NEEDED IN ORDER TO CONNECT TO MINIO USING THE AWS CODE, HARD CODED IT HAS NO EFFECT
+  AwsEndpoint: '{{ .Values.storage.minio.endpoint }}'
+  {{- end }}
+
+  {{- if and (.Values.storage.gcp).projectId (.Values.storage.gcp).bucketName (.Values.storage.gcp).credentials }}
+  #Gcp Storage
+  RegistryStorageType: 'GcpStorageImpl'
+  GcpStorageProjectId: '{{ .Values.storage.gcp.projectId }}'
+  GcpStorageBucketName: '{{ .Values.storage.gcp.bucketName }}'
+  {{- end }}
+
+  {{- end }}
+
+{{ end }}

--- a/charts/terrakube/templates/deployment-api.yaml
+++ b/charts/terrakube/templates/deployment-api.yaml
@@ -23,6 +23,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/secrets-api.yaml") . | sha256sum }}
+        checksum/configmap: {{ include (print $.Template.BasePath "/configMap-api.yaml") . | sha256sum }}
 {{- if .Values.api.otel.enabled }}
         checksum/otel-config: {{ include (print $.Template.BasePath "/otel-api.yaml") . | sha256sum }}
 {{- end }}
@@ -74,13 +75,17 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         envFrom:
-        {{- range .Values.api.secrets }}
-        - secretRef:
+        {{- range .Values.api.configMaps }}
+        - configMapRef:
             name: {{ . | quote }}
         {{- end }}
         {{- if .Values.api.otel.enabled}}
         - configMapRef:
             name: "terrakube-api-otel-config"
+        {{- end }}
+        {{- range .Values.api.secrets }}
+        - secretRef:
+            name: {{ . | quote }}
         {{- end }}
         startupProbe:
           httpGet:

--- a/charts/terrakube/templates/deployment-executor.yaml
+++ b/charts/terrakube/templates/deployment-executor.yaml
@@ -20,6 +20,7 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/secrets-executor.yaml") . | sha256sum }}
+        checksum/configmap: {{ include (print $.Template.BasePath "/configMap-executor.yaml") . | sha256sum }}
 {{- if .Values.executor.otel.enabled }}
         checksum/otel-config: {{ include (print $.Template.BasePath "/otel-executor.yaml") . | sha256sum }}
 {{- end }}
@@ -66,13 +67,17 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         envFrom:
-        {{- range .Values.executor.secrets }}
-        - secretRef:
+        {{- range .Values.executor.configMaps }}
+        - configMapRef:
             name: {{ . | quote }}
         {{- end }}
         {{- if .Values.executor.otel.enabled}}
         - configMapRef:
-          name: "terrakube-executor-otel-config"
+            name: "terrakube-executor-otel-config"
+        {{- end }}
+        {{- range .Values.executor.secrets }}
+        - secretRef:
+            name: {{ . | quote }}
         {{- end }}
         startupProbe:
           httpGet:

--- a/charts/terrakube/templates/deployment-registry.yaml
+++ b/charts/terrakube/templates/deployment-registry.yaml
@@ -23,6 +23,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         checksum/config: {{ include (print $.Template.BasePath "/secrets-registry.yaml") . | sha256sum }}
+        checksum/configmap: {{ include (print $.Template.BasePath "/configMap-registry.yaml") . | sha256sum }}
 {{- if .Values.registry.otel.enabled }}
         checksum/otel-config: {{ include (print $.Template.BasePath "/otel-registry.yaml") . | sha256sum }}
 {{- end }}
@@ -66,13 +67,17 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         envFrom:
+        {{- range .Values.registry.configMaps }}
+        - configMapRef:
+            name: {{ . | quote }}
+        {{- end }}
+        {{- if .Values.registry.otel.enabled}}
+        - configMapRef:
+            name: "terrakube-registry-otel-config"
+        {{- end }}
         {{- range .Values.registry.secrets }}
         - secretRef:
             name: {{ . | quote }}
-        {{- end }}
-        {{- if .Values.executor.otel.enabled}}
-        - configMapRef:
-          name: "terrakube-executor-otel-config"
         {{- end }}
         startupProbe:
           httpGet:

--- a/charts/terrakube/templates/secrets-api.yaml
+++ b/charts/terrakube/templates/secrets-api.yaml
@@ -7,118 +7,56 @@ metadata:
     {{- include "terrakube.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  GroupValidationType: 'DEX'
-  UserValidationType: 'DEX'
-  AuthenticationValidationType: 'DEX'
   PatSecret: '{{ .Values.security.patSecret | b64enc }}'
   InternalSecret: '{{ .Values.security.internalSecret | b64enc }}'
-  DexIssuerUri: '{{ .Values.dex.config.issuer }}'
   DexClientId: '{{ .Values.security.dexClientId }}'
-  TerrakubeToolsRepository: '{{ .Values.executor.properties.toolsRepository }}'
-  TerrakubeToolsBranch: '{{ .Values.executor.properties.toolsBranch }}'
-  TerrakubeHostname: '{{ .Values.ingress.api.domain }}'
-  AzBuilderExecutorUrl: '{{ .Values.api.properties.executorUrl }}/api/v1/terraform-rs'
-  ExecutorReplicas: '{{ .Values.api.properties.executorReplicaCount |  default .Values.executor.replicaCount }}'
-  TerrakubeUiURL: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.ui.domain }}'
-  TERRAKUBE_ADMIN_GROUP: '{{ .Values.security.adminGroup }}'
-  TerrakubeRedisPort: '{{ .Values.api.properties.redisPort }}'
-  DynamicCredentialPublicKeyPath: '{{ .Values.api.dynamicCredentials.publicKeyPath }}'
-  DynamicCredentialPrivateKeyPath: '{{ .Values.api.dynamicCredentials.privateKeyPath }}'
-  {{- if .Values.api.defaultRedis -}}
+  {{- if .Values.api.defaultRedis }}
   #Default Redis
-  TerrakubeRedisHostname: '{{ .Release.Name }}-redis-master'
   TerrakubeRedisPassword: {{ .Values.redis.auth.password }}
-  {{ else }}
+  {{- else }}
   #Custom Redis
-  TerrakubeRedisHostname: '{{ .Values.api.properties.redisHostname }}'
   TerrakubeRedisPassword: '{{ .Values.api.properties.redisPassword }}'
   {{- end }}
 
-  {{- if .Values.storage.defaultStorage -}}
+  {{- if .Values.storage.defaultStorage }}
 
-  #AWS S3 Storage
-  StorageType: 'AWS'
+  #AWS S3 Storage (default minio)
   AwsStorageAccessKey: '{{ .Values.minio.auth.rootUser }}'
   AwsStorageSecretKey: '{{ .Values.minio.auth.rootPassword }}'
-  AwsStorageBucketName: '{{ .Values.minio.defaultBuckets }}'
-  AwsStorageRegion: '{{ .Values.storage.default.region }}'
-  AwsEndpoint: {{ .Values.storage.default.endpoint | default (printf "http://%s-minio:9000" .Release.Name) | quote }} 
 
-  {{ else }}
+  {{- else }}
 
   {{- if and (.Values.storage.azure).storageAccountName (.Values.storage.azure).storageAccountAccessKey }}
   #Azure Storage
-  StorageType: 'AZURE'
-  AzureAccountName: '{{ .Values.storage.azure.storageAccountName }}'
   AzureAccountKey: '{{ .Values.storage.azure.storageAccountAccessKey }}'
   {{- end }}
-  
-  {{- if and (.Values.storage.aws).bucketName (.Values.storage.aws).region  }}
+
+  {{- if and (.Values.storage.aws).bucketName (.Values.storage.aws).region }}
   #AWS S3 Storage
-  StorageType: 'AWS'
   {{- if and (.Values.storage.aws).accessKey (.Values.storage.aws).secretKey }}
   AwsStorageAccessKey: '{{ .Values.storage.aws.accessKey }}'
   AwsStorageSecretKey: '{{ .Values.storage.aws.secretKey }}'
   {{- end }}
-  AwsStorageBucketName: '{{ .Values.storage.aws.bucketName }}'
-  AwsStorageRegion: '{{ .Values.storage.aws.region }}'
-  AwsEndpoint: ''
   {{- end }}
 
-  {{- if and (.Values.storage.minio).bucketName (.Values.storage.minio).accessKey (.Values.storage.minio).secretKey (.Values.storage.minio).endpoint  }}
+  {{- if and (.Values.storage.minio).bucketName (.Values.storage.minio).accessKey (.Values.storage.minio).secretKey (.Values.storage.minio).endpoint }}
   #MINIO S3 Storage
-  StorageType: 'AWS'
   AwsStorageAccessKey: '{{ .Values.storage.minio.accessKey }}'
   AwsStorageSecretKey: '{{ .Values.storage.minio.secretKey }}'
-  AwsStorageBucketName: '{{ .Values.storage.minio.bucketName }}'
-  AwsStorageRegion: 'us-east-1' # THIS IS NEEDED IN ORDER TO CONNECT TO MINIO USING THE AWS CODE, HARD CODED IT HAS NO EFFECT
-  AwsEndpoint: '{{ .Values.storage.minio.endpoint }}'
   {{- end }}
 
-  {{- if and (.Values.storage.gcp).projectId (.Values.storage.gcp).bucketName (.Values.storage.gcp).credentials  }}
+  {{- if and (.Values.storage.gcp).projectId (.Values.storage.gcp).bucketName (.Values.storage.gcp).credentials }}
   #GCP Storage Bucket
-  StorageType: 'GCP'
-  GcpStorageProjectId: '{{ .Values.storage.gcp.projectId }}'
-  GcpStorageBucketName: '{{ .Values.storage.gcp.bucketName }}'
   GcpStorageCredentialsBase64: {{ .Values.storage.gcp.credentials | b64enc }}
   {{- end }}
 
   {{- end }}
-  
-  {{- if .Values.api.defaultDatabase -}}
+
+  {{- if .Values.api.defaultDatabase }}
   #Checking default database options
-  DatasourceHostname: '{{ .Release.Name }}-postgresql'
-  DatasourceDatabase: '{{ .Values.postgresql.auth.database }}'
-  DatasourceUser: '{{ .Values.postgresql.auth.username}}'
   DatasourcePassword: '{{ .Values.postgresql.auth.password }}'
-  DatasourcePort: '5432'
-  ApiDataSourceType: 'POSTGRESQL'
-  DatasourceSchema: '{{ .Values.api.properties.databaseSchema }}' 
-  DatasourceSslMode: '{{ .Values.api.properties.databaseSslMode }}' 
-  {{ else }}
-  ApiDataSourceType: '{{ .Values.api.properties.databaseType }}'
-  DatasourceHostname: '{{ .Values.api.properties.databaseHostname }}'
-  DatasourceDatabase: '{{ .Values.api.properties.databaseName }}'
-  DatasourceUser: '{{ .Values.api.properties.databaseUser }}'
-  DatasourcePassword: '{{ .Values.api.properties.databasePassword }}' 
-  DatasourceSslMode: '{{ .Values.api.properties.databaseSslMode }}' 
-  DatasourcePort: '{{ .Values.api.properties.databasePort }}' 
-  DatasourceSchema: '{{ .Values.api.properties.databaseSchema }}' 
-  {{- end }}  
-
-
-  {{- if .Values.api.loadSampleData -}}
-  #Checking if we need to load the default data for testing
-  spring_profiles_active: 'demo'
-  {{- end }}  
-
-  #Custom terraform releases url
-  CustomTerraformReleasesUrl : '{{ .Values.api.terraformReleasesUrl }}' 
-  CustomTofuReleasesUrl : '{{ .Values.api.tofuReleasesUrl }}' 
-  ModuleCacheMaxTotal: '{{ .Values.api.cache.moduleCacheMaxTotal }}' 
-  ModuleCacheMaxIdle: '{{ .Values.api.cache.moduleCacheMaxIdle }}' 
-  ModuleCacheMinIdle: '{{ .Values.api.cache.moduleCacheMinIdle }}' 
-  ModuleCacheTimeout: '{{ .Values.api.cache.moduleCacheTimeout }}' 
-  ModuleCacheSchedule: '{{ .Values.api.cache.moduleCacheSchedule }}' 
+  {{- else }}
+  DatasourcePassword: '{{ .Values.api.properties.databasePassword }}'
+  {{- end }}
 
 {{ end }}

--- a/charts/terrakube/templates/secrets-executor.yaml
+++ b/charts/terrakube/templates/secrets-executor.yaml
@@ -7,107 +7,55 @@ metadata:
     {{- include "terrakube.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  # General Settings
-  AzBuilderApiUrl: '{{ .Values.executor.apiServiceUrl }}'
   InternalSecret: '{{ .Values.security.internalSecret | b64enc }}'
-
-  ExecutorFlagBatch: 'false'
-  ExecutorFlagDisableAcknowledge: 'false'
-  TerrakubeToolsRepository: '{{ .Values.executor.properties.toolsRepository }}'
-  TerrakubeToolsBranch: '{{ .Values.executor.properties.toolsBranch }}'
-  TerrakubeEnableSecurity: 'true'
-  TerrakubeRegistryDomain: '{{ .Values.ingress.registry.domain }}'
-  TerrakubeApiUrl: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.api.domain }}'
-  TerrakubeRedisPort: '{{ .Values.api.properties.redisPort }}'
-  {{- if .Values.api.defaultRedis -}}
+  {{- if .Values.api.defaultRedis }}
   #Default Redis
-  TerrakubeRedisHostname: '{{ .Release.Name }}-redis-master'
   TerrakubeRedisPassword: '{{ .Values.redis.auth.password }}'
-  {{ else }}
+  {{- else }}
   #Custom Redis
-  TerrakubeRedisHostname: '{{ .Values.api.properties.redisHostname }}'
   TerrakubeRedisPassword: '{{ .Values.api.properties.redisPassword }}'
-
   {{- end }}
 
-  {{- if .Values.storage.defaultStorage -}}
+  {{- if .Values.storage.defaultStorage }}
 
   #AWS S3 Storage using MINIO
-  TerraformStateType: 'AwsTerraformStateImpl'
   AwsTerraformStateAccessKey: '{{ .Values.minio.auth.rootUser }}'
   AwsTerraformStateSecretKey: '{{ .Values.minio.auth.rootPassword }}'
-  AwsTerraformStateBucketName: '{{ .Values.minio.defaultBuckets }}'
-  AwsTerraformStateRegion: '{{ .Values.storage.default.region }}'
-  TerraformOutputType: 'AwsTerraformOutputImpl'
   AwsTerraformOutputAccessKey: '{{ .Values.minio.auth.rootUser }}'
   AwsTerraformOutputSecretKey: '{{ .Values.minio.auth.rootPassword }}'
-  AwsTerraformOutputBucketName: '{{ .Values.minio.defaultBuckets }}'
-  AwsTerraformOutputRegion: '{{ .Values.storage.default.region }}'
-  AwsEndpoint: {{ .Values.storage.default.endpoint | default (printf "http://%s-minio:9000" .Release.Name) | quote }} 
 
-  {{ else }}
+  {{- else }}
 
   {{- if and (.Values.storage.azure).storageAccountName (.Values.storage.azure).storageAccountAccessKey }}
   #Azure Storage
-  TerraformStateType: 'AzureTerraformStateImpl'
-  AzureTerraformStateResourceGroup: '{{ .Values.storage.azure.storageAccountResourceGroup }}'
-  AzureTerraformStateStorageAccountName: '{{ .Values.storage.azure.storageAccountName }}'
-  AzureTerraformStateStorageContainerName: 'tfstate'
   AzureTerraformStateStorageAccessKey: '{{ .Values.storage.azure.storageAccountAccessKey }}'
-  TerraformOutputType: 'AzureTerraformOutputImpl'
-  AzureTerraformOutputAccountName: '{{ .Values.storage.azure.storageAccountName }}'
   AzureTerraformOutputAccountKey: '{{ .Values.storage.azure.storageAccountAccessKey }}'
   {{- end }}
-  
-  {{- if and (.Values.storage.aws).bucketName (.Values.storage.aws).region  }}
+
+  {{- if and (.Values.storage.aws).bucketName (.Values.storage.aws).region }}
   #AWS S3 Storage
-  TerraformStateType: 'AwsTerraformStateImpl'
   {{- if and (.Values.storage.aws).accessKey (.Values.storage.aws).secretKey }}
   AwsTerraformStateAccessKey: '{{ .Values.storage.aws.accessKey }}'
   AwsTerraformStateSecretKey: '{{ .Values.storage.aws.secretKey }}'
-  {{- end }}
-  AwsTerraformStateBucketName: '{{ .Values.storage.aws.bucketName }}'
-  AwsTerraformStateRegion: '{{ .Values.storage.aws.region }}'
-  TerraformOutputType: 'AwsTerraformOutputImpl'
-  {{- if and (.Values.storage.aws).accessKey (.Values.storage.aws).secretKey }}
   AwsTerraformOutputAccessKey: '{{ .Values.storage.aws.accessKey }}'
   AwsTerraformOutputSecretKey: '{{ .Values.storage.aws.secretKey }}'
   {{- end }}
-  AwsTerraformOutputBucketName: '{{ .Values.storage.aws.bucketName }}'
-  AwsTerraformOutputRegion: '{{ .Values.storage.aws.region }}'
-  AwsEndpoint: ''
   {{- end }}
 
-  {{- if and (.Values.storage.minio).bucketName (.Values.storage.minio).accessKey (.Values.storage.minio).secretKey (.Values.storage.minio).endpoint  }}
+  {{- if and (.Values.storage.minio).bucketName (.Values.storage.minio).accessKey (.Values.storage.minio).secretKey (.Values.storage.minio).endpoint }}
   #MINIO S3 Storage
-  TerraformStateType: 'AwsTerraformStateImpl' # MINIO USES THE AWS LIBRARY
   AwsTerraformStateAccessKey: '{{ .Values.storage.minio.accessKey }}'
   AwsTerraformStateSecretKey: '{{ .Values.storage.minio.secretKey }}'
-  AwsTerraformStateBucketName: '{{ .Values.storage.minio.bucketName }}'
-  AwsTerraformStateRegion: 'us-east-1' # THIS IS NEEDED IN ORDER TO CONNECT TO MINIO USING THE AWS CODE, HARD CODED IT HAS NO EFFECT
-  TerraformOutputType: 'AwsTerraformOutputImpl' # MINIO USES THE AWS LIBRARY
   AwsTerraformOutputAccessKey: '{{ .Values.storage.minio.accessKey }}'
   AwsTerraformOutputSecretKey: '{{ .Values.storage.minio.secretKey }}'
-  AwsTerraformOutputBucketName: '{{ .Values.storage.minio.bucketName }}'
-  AwsTerraformOutputRegion: 'us-east-1' # THIS IS NEEDED IN ORDER TO CONNECT TO MINIO USING THE AWS CODE, HARD CODED IT HAS NO EFFECT
-  AwsEndpoint: '{{ .Values.storage.minio.endpoint }}'
   {{- end }}
 
-  {{- if and (.Values.storage.gcp).projectId (.Values.storage.gcp).bucketName (.Values.storage.gcp).credentials  }}
+  {{- if and (.Values.storage.gcp).projectId (.Values.storage.gcp).bucketName (.Values.storage.gcp).credentials }}
   #GCP Storage Bucket
-  TerraformStateType: 'GcpTerraformStateImpl'
-  GcpTerraformStateProjectId: '{{ .Values.storage.gcp.projectId }}'
-  GcpTerraformStateBucketName: '{{ .Values.storage.gcp.bucketName }}'
   GcpTerraformStateCredentials: '{{ .Values.storage.gcp.credentials | b64enc }}'
-  TerraformOutputType: 'GcpTerraformOutputImpl'
-  GcpTerraformOutputProjectId: '{{ .Values.storage.gcp.projectId }}'
-  GcpTerraformOutputBucketName: '{{ .Values.storage.gcp.bucketName }}'
   GcpTerraformOutputCredentials: '{{ .Values.storage.gcp.credentials | b64enc }}'
   {{- end }}
 
-  {{- end }} 
-
-  #Custom terraform releases url
-  CustomTerraformReleasesUrl : '{{ .Values.api.terraformReleasesUrl }}' 
+  {{- end }}
 
 {{ end }}

--- a/charts/terrakube/templates/secrets-registry.yaml
+++ b/charts/terrakube/templates/secrets-registry.yaml
@@ -7,66 +7,42 @@ metadata:
     {{- include "terrakube.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  AzBuilderRegistry: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.registry.domain }}'
-  AzBuilderApiUrl: 'http://terrakube-api-service:8080'
-  AuthenticationValidationTypeRegistry: 'DEX'
   PatSecret: '{{ .Values.security.patSecret | b64enc}}'
   InternalSecret: '{{ .Values.security.internalSecret | b64enc }}'
-  DexIssuerUri: '{{ .Values.dex.config.issuer }}'
-  TerrakubeEnableSecurity: 'true'
-  TerrakubeUiURL: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.ui.domain }}'
   AppClientId: '{{ .Values.security.dexClientId }}'
-  AppIssuerUri: '{{ .Values.dex.config.issuer }}'
 
-
-  {{- if .Values.storage.defaultStorage -}}
+  {{- if .Values.storage.defaultStorage }}
 
   #AWS S3 Storage using MINIO
-  RegistryStorageType: 'AwsStorageImpl'
   AwsStorageAccessKey: '{{ .Values.minio.auth.rootUser }}'
   AwsStorageSecretKey: '{{ .Values.minio.auth.rootPassword }}'
-  AwsStorageBucketName: '{{ .Values.minio.defaultBuckets }}'
-  AwsStorageRegion: '{{ .Values.storage.default.region }}'
-  AwsEndpoint: {{ .Values.storage.default.endpoint | default (printf "http://%s-minio:9000" .Release.Name) | quote }} 
 
-  {{ else }}
+  {{- else }}
 
   {{- if and (.Values.storage.azure).storageAccountName (.Values.storage.azure).storageAccountAccessKey }}
   #Azure Storage
-  RegistryStorageType: 'AzureStorageImpl'
-  AzureAccountName: '{{ .Values.storage.azure.storageAccountName }}'
   AzureAccountKey: '{{ .Values.storage.azure.storageAccountAccessKey }}'
   {{- end }}
-  
-  {{- if and (.Values.storage.aws).bucketName (.Values.storage.aws).region  }}
+
+  {{- if and (.Values.storage.aws).bucketName (.Values.storage.aws).region }}
   #Aws Storage
-  RegistryStorageType: 'AwsStorageImpl'
   {{- if and (.Values.storage.aws).accessKey (.Values.storage.aws).secretKey }}
   AwsStorageAccessKey: '{{ .Values.storage.aws.accessKey }}'
   AwsStorageSecretKey: '{{ .Values.storage.aws.secretKey }}'
   {{- end }}
-  AwsStorageBucketName: '{{ .Values.storage.aws.bucketName }}'
-  AwsStorageRegion: '{{ .Values.storage.aws.region }}'
-  AwsEndpoint: ''
   {{- end }}
 
-  {{- if and (.Values.storage.minio).bucketName (.Values.storage.minio).accessKey (.Values.storage.minio).secretKey (.Values.storage.minio).endpoint  }}
+  {{- if and (.Values.storage.minio).bucketName (.Values.storage.minio).accessKey (.Values.storage.minio).secretKey (.Values.storage.minio).endpoint }}
   #MINIO Storage
-  RegistryStorageType: 'AwsStorageImpl'
   AwsStorageAccessKey: '{{ .Values.storage.minio.accessKey }}'
   AwsStorageSecretKey: '{{ .Values.storage.minio.secretKey }}'
-  AwsStorageBucketName: '{{ .Values.storage.minio.bucketName }}'
-  AwsStorageRegion: 'us-east-1' # THIS IS NEEDED IN ORDER TO CONNECT TO MINIO USING THE AWS CODE, HARD CODED IT HAS NO EFFECT
-  AwsEndpoint: '{{ .Values.storage.minio.endpoint }}'
   {{- end }}
 
-  {{- if and (.Values.storage.gcp).projectId (.Values.storage.gcp).bucketName (.Values.storage.gcp).credentials  }}
+  {{- if and (.Values.storage.gcp).projectId (.Values.storage.gcp).bucketName (.Values.storage.gcp).credentials }}
   #Gcp Storage
-  RegistryStorageType: 'GcpStorageImpl'
-  GcpStorageProjectId: '{{ .Values.storage.gcp.projectId }}'
-  GcpStorageBucketName: '{{ .Values.storage.gcp.bucketName }}'
   GcpStorageCredentialsBase64: '{{ .Values.storage.gcp.credentials | b64enc }}'
   {{- end }}
 
-  {{- end }} 
+  {{- end }}
+
 {{ end }}

--- a/charts/terrakube/values.schema.json
+++ b/charts/terrakube/values.schema.json
@@ -188,6 +188,12 @@
                         "type": "string"
                     }
                 },
+                "configMaps": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "securityContext": {
                     "type": "object"
                 },
@@ -535,6 +541,12 @@
                     "type": "integer"
                 },
                 "secrets": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "configMaps": {
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -1071,6 +1083,12 @@
                     "type": "integer"
                 },
                 "secrets": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "configMaps": {
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -222,6 +222,8 @@ api:
     secretName: terrakube-executor-secrets
   secrets:
    - terrakube-api-secrets
+  configMaps:
+   - terrakube-api-config
   resources: {}
   podLabels: {}
   podAnnotations: {}
@@ -278,6 +280,8 @@ executor:
   revisionHistoryLimit: 3
   secrets:
    - terrakube-executor-secrets
+  configMaps:
+   - terrakube-executor-config
   otel:
     enabled: false
     metrics:
@@ -319,6 +323,8 @@ registry:
   revisionHistoryLimit: 3
   secrets:
    - terrakube-registry-secrets
+  configMaps:
+   - terrakube-registry-config
   otel:
     enabled: false
     metrics:


### PR DESCRIPTION
## Summary

Separates Terrakube configuration into confidential and non-confidential data to improve integration with external secret management systems such as External Secrets Operator.

Move non-sensitive configuration values out of Secrets and into ConfigMaps, so that Secrets contain only sensitive information.

### Changes

- Add `configMap-api.yaml`, `configMap-executor.yaml`, and `configMap-registry.yaml`
- Update api / executor / registry Deployments to load non-sensitive env vars from ConfigMaps and sensitive env vars from Secrets
- Remove non-sensitive values (hostnames, URLs, type identifiers, etc.) from Secrets
- Update `values.yaml` and `values.schema.json`

### Examples of values moved (Secret → ConfigMap)

**api:** `ApiDataSourceType`, `AuthenticationValidationType`, `AzBuilderExecutorUrl`, `DatasourceHostname`, `DatasourcePort`, `DatasourceSchema`, `DatasourceSslMode`, `DatasourceUser`, `DexIssuerUri`, `StorageType`, `TerrakubeHostname`, etc.

**executor:** `AzBuilderApiUrl`, `CustomTerraformReleasesUrl`, `ExecutorFlagBatch`, `ExecutorFlagDisableAcknowledge`, `TerraformOutputType`, `TerraformStateType`, `TerrakubeApiUrl`, `TerrakubeRegistryDomain`, etc.

**registry:** `AppIssuerUri`, `AuthenticationValidationTypeRegistry`, `AzBuilderApiUrl`, `AzBuilderRegistry`, `DexIssuerUri`, `RegistryStorageType`, etc.

### Values remaining in Secret (sensitive)

Passwords, access keys, secret keys, `InternalSecret`, `PatSecret`, `TerrakubeRedisPassword`, etc.

## Test Plan

### 1. Capture baseline environment variables from the released chart (terrakube-4.5.9)

Installed the released chart and recorded env vars for each Pod.

```console
helm repo list
# NAME            URL
# terrakube-repo  https://charts.terrakube.io

helm install terrakube terrakube-repo/terrakube -n terrakube
kubectl get pods -n terrakube
# All pods Running

kubectl exec -n terrakube -it terrakube-api-<hash> -- env | sort
kubectl exec -n terrakube -it terrakube-executor-<hash> -- env | sort
kubectl exec -n terrakube -it terrakube-registry-<hash> -- env | sort
```

### 2. Fresh install with this PR's chart — no Pod errors and no diff in env vars

```console
helm install terrakube ./charts/terrakube/ -n terrakube
kubectl get po -n terrakube
# All pods Running

kubectl exec -n terrakube -it terrakube-api-<hash> -- env | sort
kubectl exec -n terrakube -it terrakube-executor-<hash> -- env | sort
kubectl exec -n terrakube -it terrakube-registry-<hash> -- env | sort
```

Confirmed that env var values match those from the baseline (step 1).

### 3. Backward compatibility — Secret values override ConfigMap values

Verified that an existing Secret containing extra keys (non-sensitive values that have since moved to ConfigMap) still takes precedence, so existing deployments are not disrupted.

```console
# Manually add a duplicate key (TerrakubeUiURL) to the Secret to test override behavior
kubectl edit secret -n terrakube terrakube-api-secrets
# Added TerrakubeUiURL: ZXhhbXBsZS1hcHA= (= "example-app")

kubectl rollout restart -n terrakube deploy/terrakube-api
kubectl exec -n terrakube -it terrakube-api-<hash> -- env | sort | findstr "TerrakubeUiURL"
# TerrakubeUiURL=example-app
# → Secret value overrides the ConfigMap value as expected
```

This confirms that existing environments with extra keys remaining in their Secrets will continue to work without disruption.
