### PR TITLE
feat(ephemeralExecution): add multi-secret, configMapName, and podAnnotations support

### DIFF
--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.6.0
+version: 4.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/templates/deployment-api.yaml
+++ b/charts/terrakube/templates/deployment-api.yaml
@@ -56,7 +56,19 @@ spec:
         - name: ExecutorEphemeralImage
           value: {{ .Values.executor.image }}:{{ default .Chart.AppVersion .Values.executor.version }}
         - name: ExecutorEphemeralSecret
-          value: {{ .Values.api.ephemeralExecution.secretName }}
+          {{- if kindIs "string" .Values.api.ephemeralExecution.secretName }}
+          value: {{ .Values.api.ephemeralExecution.secretName | quote }}
+          {{- else }}
+          value: {{ .Values.api.ephemeralExecution.secretName | join "," | quote }}
+          {{- end }}
+        {{- if .Values.api.ephemeralExecution.podAnnotations }}
+        - name: ExecutorEphemeralPodAnnotations
+          value: {{ .Values.api.ephemeralExecution.podAnnotations | toJson | quote }}
+        {{- end }}
+        {{- if .Values.api.ephemeralExecution.configMapName }}
+        - name: ExecutorEphemeralConfigMap
+          value: {{ .Values.api.ephemeralExecution.configMapName | quote }}
+        {{- end }}
         {{- end }}
         {{- if .Values.security.caCerts }}
         - name: SERVICE_BINDING_ROOT

--- a/charts/terrakube/values.schema.json
+++ b/charts/terrakube/values.schema.json
@@ -161,7 +161,16 @@
                             "type": "boolean"
                         },
                         "secretName": {
+                            "oneOf": [
+                                { "type": "string" },
+                                { "type": "array", "items": { "type": "string" } }
+                            ]
+                        },
+                        "configMapName": {
                             "type": "string"
+                        },
+                        "podAnnotations": {
+                            "type": "object"
                         }
                     }
                 },

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -219,7 +219,10 @@ api:
     roleBindingName: "terrakube-api-role-binding"
   ephemeralExecution:
     enabled: false
-    secretName: terrakube-executor-secrets
+    secretName:
+      - terrakube-executor-secrets
+    configMapName: ""
+    podAnnotations: {}
   secrets:
    - terrakube-api-secrets
   configMaps:


### PR DESCRIPTION
## Summary

Extends `api.ephemeralExecution` to support passing additional configuration to executor pods.

- `secretName` promoted from scalar string to list — multiple secrets are comma-joined into the existing `ExecutorEphemeralSecret` env var. **Backward compatible**: scalar string values still work.
- New optional `configMapName` field — rendered as `ExecutorEphemeralConfigMap` env var when set.
- New optional `podAnnotations` field (map) — rendered as `ExecutorEphemeralPodAnnotations` env var (JSON-encoded) when set.

## Related

Helm chart companion to terrakube-io/terrakube#3149, which implements the application-side changes that read these env vars. Both PRs are required for full functionality.

## values.yaml

```yaml
api:
  ephemeralExecution:
    enabled: true
    secretName:
      - terrakube-executor-secrets   # single or multiple secrets
      - my-extra-secret
    configMapName: ""                # optional ConfigMap name
    podAnnotations: {}               # optional pod annotations (map)
```

## New / updated env vars on the API deployment

| Env var | Condition |
|---|---|
| `ExecutorEphemeralSecret` | always — comma-joined list or passthrough scalar |
| `ExecutorEphemeralConfigMap` | when `configMapName` is non-empty |
| `ExecutorEphemeralPodAnnotations` | when `podAnnotations` is non-empty (JSON-encoded map) |

## Schema

`values.schema.json` updated under `api.ephemeralExecution`:
- `secretName`: `string \| string[]`
- `configMapName`: `string`
- `podAnnotations`: `object`

## Test plan

- [ ] `helm lint` passes with default values
- [ ] Scalar `secretName` (via `--set`) renders correctly (backcompat)
- [ ] List `secretName` with multiple entries comma-joins correctly
- [ ] Non-empty `configMapName` renders `ExecutorEphemeralConfigMap`
- [ ] Non-empty `podAnnotations` map renders `ExecutorEphemeralPodAnnotations` as JSON string
- [ ] Empty `podAnnotations: {}` does **not** render the env var