### PR TITLE
chore: Optionally provide per-service SSLPolicy to GKE FrontendConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,8 +442,12 @@ Once you have completed the above steps you can complete the file values.yaml to
 | ingress.gke.backendConfig.uiSecurityPolicy      | No       | Cloud Armor security policy for UI service (restrict user access)     |
 | ingress.gke.backendConfig.apiSecurityPolicy     | No       | Cloud Armor security policy for API service (usually empty)           |
 | ingress.gke.backendConfig.registrySecurityPolicy | No       | Cloud Armor security policy for Registry service (usually empty)      |
-| ingress.gke.backendConfig.executorSecurityPolicy | No       | Cloud Armor security policy for Executor service (usually empty)      '
+| ingress.gke.backendConfig.executorSecurityPolicy | No       | Cloud Armor security policy for Executor service (usually empty)      |
 | ingress.gke.frontendConfig.create         | No       | Create FrontendConfig resources (default: false)                      |
+| ingress.gke.frontendConfig.uiSslPolicy      | No       | SSL policy for UI service     |
+| ingress.gke.frontendConfig.apiSslPolicy     | No       | SSL policy for API service           |
+| ingress.gke.frontendConfig.registrySslPolicy | No       | SSL policy for Registry service      |
+| ingress.gke.frontendConfig.executorSslPolicy | No       | SSL policy for Executor service      |
 | ingress.gke.externalDNS.perIngressProxy   | No       | Per-service Cloudflare proxy settings                                 |
 | ingress.gke.annotations                   | No       | Global GKE annotations applied to all ingresses                       |
 | ingress.gke.uiStaticIPName                | No       | GCP static IP name for UI service                                      |

--- a/charts/terrakube/templates/gke/api-frontendconfig.yaml
+++ b/charts/terrakube/templates/gke/api-frontendconfig.yaml
@@ -6,4 +6,7 @@ metadata:
 spec:
   redirectToHttps:
     enabled: {{ .Values.ingress.gke.frontendConfig.redirectToHttps }}
+  {{- if .Values.ingress.gke.frontendConfig.apiSslPolicy }}
+  sslPolicy: {{ .Values.ingress.gke.frontendConfig.apiSslPolicy }}
+  {{- end }}
 {{- end }}

--- a/charts/terrakube/templates/gke/executor-frontendconfig.yaml
+++ b/charts/terrakube/templates/gke/executor-frontendconfig.yaml
@@ -6,4 +6,7 @@ metadata:
 spec:
   redirectToHttps:
     enabled: {{ .Values.ingress.gke.frontendConfig.redirectToHttps }}
+  {{- if .Values.ingress.gke.frontendConfig.executorSslPolicy }}
+  sslPolicy: {{ .Values.ingress.gke.frontendConfig.executorSslPolicy }}
+  {{- end }}
 {{- end }}

--- a/charts/terrakube/templates/gke/registry-frontendconfig.yaml
+++ b/charts/terrakube/templates/gke/registry-frontendconfig.yaml
@@ -6,4 +6,7 @@ metadata:
 spec:
   redirectToHttps:
     enabled: {{ .Values.ingress.gke.frontendConfig.redirectToHttps }}
+  {{- if .Values.ingress.gke.frontendConfig.registrySslPolicy }}
+  sslPolicy: {{ .Values.ingress.gke.frontendConfig.registrySslPolicy }}
+  {{- end }}
 {{- end }}

--- a/charts/terrakube/templates/gke/ui-frontendconfig.yaml
+++ b/charts/terrakube/templates/gke/ui-frontendconfig.yaml
@@ -6,4 +6,7 @@ metadata:
 spec:
   redirectToHttps:
     enabled: {{ .Values.ingress.gke.frontendConfig.redirectToHttps }}
+  {{- if .Values.ingress.gke.frontendConfig.uiSslPolicy }}
+  sslPolicy: {{ .Values.ingress.gke.frontendConfig.uiSslPolicy }}
+  {{- end }}
 {{- end }}

--- a/charts/terrakube/values.schema.json
+++ b/charts/terrakube/values.schema.json
@@ -162,8 +162,15 @@
                         },
                         "secretName": {
                             "oneOf": [
-                                { "type": "string" },
-                                { "type": "array", "items": { "type": "string" } }
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
                             ]
                         },
                         "configMapName": {
@@ -826,6 +833,18 @@
                                 },
                                 "redirectToHttps": {
                                     "type": "boolean"
+                                },
+                                "apiSslPolicy": {
+                                    "type": "string"
+                                },
+                                "executorSslPolicy": {
+                                    "type": "string"
+                                },
+                                "registrySslPolicy": {
+                                    "type": "string"
+                                },
+                                "uiSslPolicy": {
+                                    "type": "string"
                                 }
                             }
                         },

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -479,6 +479,11 @@ ingress:
     frontendConfig:
       create: false
       redirectToHttps: true
+      # Per-service SSL policies (optional)
+      uiSslPolicy: "fake"   # SSL policy for UI
+      apiSslPolicy: ""      # SSL policy for API
+      registrySslPolicy: "" # SSL policy for Registry
+      executorSslPolicy: "" # SSL policy for Executor
     externalDNS:
       perIngressProxy:         # Control whether ExternalDNS creates proxy records (Cloudflare)
         ui: false

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -480,7 +480,7 @@ ingress:
       create: false
       redirectToHttps: true
       # Per-service SSL policies (optional)
-      uiSslPolicy: "fake"   # SSL policy for UI
+      uiSslPolicy: ""       # SSL policy for UI
       apiSslPolicy: ""      # SSL policy for API
       registrySslPolicy: "" # SSL policy for Registry
       executorSslPolicy: "" # SSL policy for Executor


### PR DESCRIPTION
The PR aim to add the possibility to provide SSLPolicies on a per service base.

https://docs.cloud.google.com/kubernetes-engine/docs/how-to/ingress-configuration#ssl