### PR TITLE
feat: add PodDisruptionBudget support for api, executor, registry und ui

### DIFF
--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.6.6
+version: 4.6.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/templates/pdb-api.yaml
+++ b/charts/terrakube/templates/pdb-api.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.api.enabled .Values.api.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: terrakube-api-pdb
+  labels:
+    {{- include "terrakube.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "terrakube-api.labels" . | nindent 6 }}
+  {{- if .Values.api.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.api.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.api.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.api.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/charts/terrakube/templates/pdb-executor.yaml
+++ b/charts/terrakube/templates/pdb-executor.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.executor.enabled .Values.executor.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: terrakube-executor-pdb
+  labels:
+    {{- include "terrakube.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "terrakube-executor.labels" . | nindent 6 }}
+  {{- if .Values.executor.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.executor.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.executor.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.executor.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/charts/terrakube/templates/pdb-registry.yaml
+++ b/charts/terrakube/templates/pdb-registry.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.registry.enabled .Values.registry.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: terrakube-registry-pdb
+  labels:
+    {{- include "terrakube.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "terrakube-registry.labels" . | nindent 6 }}
+  {{- if .Values.registry.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.registry.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.registry.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.registry.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/charts/terrakube/templates/pdb-ui.yaml
+++ b/charts/terrakube/templates/pdb-ui.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.ui.enabled .Values.ui.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: terrakube-ui-pdb
+  labels:
+    {{- include "terrakube.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "terrakube-ui.labels" . | nindent 6 }}
+  {{- if .Values.ui.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.ui.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.ui.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.ui.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -239,6 +239,12 @@ api:
   containerSecurityContext: {}
   imagePullSecrets: []
   initContainers: []
+  podDisruptionBudget:
+    enabled: false
+    ## minAvailable and maxUnavailable are mutually exclusive, use only one.
+    ## Can be an integer (e.g. 1) or a percentage string (e.g. "50%")
+    minAvailable: 1
+    # maxUnavailable: 1
   startupProbe:
     initialDelaySeconds: 30
     failureThreshold: 30
@@ -305,6 +311,12 @@ executor:
   containerSecurityContext: {}
   imagePullSecrets: []
   initContainers: []
+  podDisruptionBudget:
+    enabled: false
+    ## minAvailable and maxUnavailable are mutually exclusive, use only one.
+    ## Can be an integer (e.g. 1) or a percentage string (e.g. "50%")
+    minAvailable: 1
+    # maxUnavailable: 1
   startupProbe:
     failureThreshold: 30
     periodSeconds: 5
@@ -344,6 +356,12 @@ registry:
   containerSecurityContext: {}
   imagePullSecrets: []
   initContainers: []
+  podDisruptionBudget:
+    enabled: false
+    ## minAvailable and maxUnavailable are mutually exclusive, use only one.
+    ## Can be an integer (e.g. 1) or a percentage string (e.g. "50%")
+    minAvailable: 1
+    # maxUnavailable: 1
   startupProbe:
     failureThreshold: 30
     periodSeconds: 5
@@ -370,6 +388,12 @@ ui:
   containerSecurityContext: {}
   imagePullSecrets: []
   initContainers: []
+  podDisruptionBudget:
+    enabled: false
+    ## minAvailable and maxUnavailable are mutually exclusive, use only one.
+    ## Can be an integer (e.g. 1) or a percentage string (e.g. "50%")
+    minAvailable: 1
+    # maxUnavailable: 1
 
 ## Ingress properties
 ingress:


### PR DESCRIPTION
## Description

This PR adds optional **PodDisruptionBudget (PDB)** support for all four Terrakube components: `api`, `executor`, `registry`, and `ui`.

PDBs ensure high availability by limiting the number of pods that can be simultaneously disrupted during voluntary events such as node drains or cluster upgrades.

## Changes

- Added `templates/pdb-api.yaml`
- Added `templates/pdb-executor.yaml`
- Added `templates/pdb-registry.yaml`
- Added `templates/pdb-ui.yaml`
- Updated `values.yaml` with `podDisruptionBudget` block for each component

## Usage

PDB is **opt-in** and disabled by default to avoid breaking existing single-replica deployments:

```yaml
api:
  podDisruptionBudget:
    enabled: true
    minAvailable: 1   # or use maxUnavailable instead
```

⚠️ For replicaCount: 1 deployments, use minAvailable: 0 or maxUnavailable: 1 to prevent node drain from being blocked.

> The chart version has not been bumped intentionally — 
> happy to update it if needed before merge.

cc @alfespa17 — could you review and merge this if it looks good? 🙏