### PR TITLE
Add port name to OTEL port in registry Service

### DIFF
--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.7.1
+version: 4.7.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/templates/service-registry.yaml
+++ b/charts/terrakube/templates/service-registry.yaml
@@ -24,7 +24,8 @@ spec:
       protocol: TCP
       name: http
 {{- if and .Values.registry.otel.enabled .Values.registry.otel.metrics }}
-    - port: {{ .Values.registry.otel.metrics.port | default "9464" }}
+    - name: otel-metrics
+      port: {{ .Values.registry.otel.metrics.port | default "9464" }}
       targetPort: metrics
 {{- end }}
   selector:


### PR DESCRIPTION
- When a Service has multiple port, port names are required to avoid ambiguity. https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services
- Issue: https://github.com/terrakube-io/terrakube-helm-chart/issues/280