### PR TITLE
feat(executor): expose readiness/watchdog tuning for multiple executor replicas

### DIFF
--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.7.5
+version: 4.7.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/templates/configMap-executor.yaml
+++ b/charts/terrakube/templates/configMap-executor.yaml
@@ -10,6 +10,7 @@ data:
   AzBuilderApiUrl: '{{ .Values.executor.apiServiceUrl }}'
   ExecutorFlagBatch: 'false'
   ExecutorFlagDisableAcknowledge: 'false'
+  ExecutorJobMaxDurationMinutes: '{{ .Values.executor.properties.maxJobDurationMinutes | default 360 }}'
   TerrakubeToolsRepository: '{{ .Values.executor.properties.toolsRepository }}'
   TerrakubeToolsBranch: '{{ .Values.executor.properties.toolsBranch }}'
   TerrakubeEnableSecurity: 'true'

--- a/charts/terrakube/templates/deployment-executor.yaml
+++ b/charts/terrakube/templates/deployment-executor.yaml
@@ -95,6 +95,7 @@ spec:
             path: /actuator/health/readiness
             port: 8090
           periodSeconds: {{ .Values.executor.readinessProbe.periodSeconds }}
+          failureThreshold: {{ .Values.executor.readinessProbe.failureThreshold | default 1 }}
         {{- with .Values.executor.containerSecurityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -289,6 +289,8 @@ executor:
   enabled: true
   image: "azbuilder/executor"
   version: ""
+  # Static pool size - no autoscaling. Size this to your expected peak concurrent job count,
+  # since each pod only runs one job at a time (see executor readiness/watchdog notes above).
   replicaCount: "1"
   serviceType: ClusterIP
   serviceAccountName: ""
@@ -313,6 +315,9 @@ executor:
   properties:
     toolsRepository: "https://github.com/terrakube-io/terrakube-extensions"
     toolsBranch: "main"
+    # Longest a single job may run before this pod is marked unhealthy (liveness) so
+    # Kubernetes restarts it - covers a hung terraform process or infinite-looping hook script.
+    maxJobDurationMinutes: "360"
   securityContext: {}
   containerSecurityContext: {}
   imagePullSecrets: []
@@ -327,7 +332,11 @@ executor:
     failureThreshold: 30
     periodSeconds: 5
   readinessProbe:
-    periodSeconds: 10
+    # Low periodSeconds/failureThreshold so a pod that just started a job is pulled out of
+    # the Service's endpoints almost immediately, instead of the Kubernetes default of 3
+    # consecutive failures (~2 extra probe cycles of routing new jobs to a busy pod).
+    periodSeconds: 2
+    failureThreshold: 1
   livenessProbe:
     periodSeconds: 10
 


### PR DESCRIPTION
### What was added and why

The chart-side companion to the terrakube app change above: exposes the new executor watchdog timeout and tunes the readiness probe so the executor is actually safe to run with `replicaCount > 1` in production.

### How it was done

- `configMap-executor.yaml`: adds `ExecutorJobMaxDurationMinutes`, sourced from the new `executor.properties.maxJobDurationMinutes` value (default 360).
- `deployment-executor.yaml`: adds `failureThreshold` to the executor's `readinessProbe` (defaults to 1) so a pod that just picked up a job drops out of the Service's endpoints almost immediately, instead of after ~2 extra probe cycles at Kubernetes' default of 3 consecutive failures.
- `values.yaml`: documents the new `executor.properties.maxJobDurationMinutes` and tightened `executor.readinessProbe.periodSeconds` (10 → 2) / `failureThreshold` defaults, plus a comment noting `executor.replicaCount` should be sized to expected peak concurrent job count since each pod still only runs one job at a time.

### Any tests added

N/A — this is template/values wiring with no chart test suite. Verified manually: `helm upgrade` against a local minikube cluster running 5 executor replicas, confirming readiness toggling and the liveness watchdog behave correctly end-to-end under concurrent job load.

This is paired with https://github.com/terrakube-io/terrakube/pull/3353