### PR TITLE
feat(executor): configure terminationGracePeriodSeconds for graceful shutdown

### DIFF
--- a/charts/terrakube/templates/deployment-executor.yaml
+++ b/charts/terrakube/templates/deployment-executor.yaml
@@ -28,6 +28,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.executor.terminationGracePeriodSeconds | default 60 }}
       {{- with .Values.executor.imagePullSecrets | default .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -290,6 +290,9 @@ executor:
   image: "azbuilder/executor"
   version: ""
   replicaCount: "1"
+  # Gives the pod's @PreDestroy hook (JobExecutionWatchdog.onShutdown) time to fail an
+  # in-flight job's status before Kubernetes SIGKILLs the process.
+  terminationGracePeriodSeconds: 60
   serviceType: ClusterIP
   serviceAccountName: ""
   revisionHistoryLimit: 3


### PR DESCRIPTION
## Summary

Companion chart change for terrakube-io/terrakube#3387 — the executor now fails its in-flight job immediately on SIGTERM (graceful shutdown, e.g. a rollout or scale-down) rather than leaving it stuck until a heartbeat times out. That shutdown hook needs a bit more time than Kubernetes' 30s default grace period to make its callback to the api reliably, especially under a rolling deploy where the api pod may also be mid-restart.

## What changed

- Added `executor.terminationGracePeriodSeconds` to `values.yaml`, defaulting to `60`
- Wired it into the executor Deployment's pod spec in `deployment-executor.yaml`

## Testing

- `helm template` verified the value renders correctly on the executor Deployment
- Verified live against a local minikube cluster running the paired application-side change — confirmed the executor pod respects the extended grace period on rollout and reliably reports its in-flight job as failed before termination