### PR TITLE
Can set custom https port for UI/API/Registry/Executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ Once you have completed the above steps you can complete the file values.yaml to
 | ingress.includeTlsHosts                   | No       | Include TLS hosts in ingress configuration (default: true)             |
 | ingress.ui.enabled                        | Yes      | Enable UI ingress (default: true)                                      |
 | ingress.ui.domain                         | Yes      | Domain name for UI service                                             |
+| ingress.ui.port                           | No       | Custom port for UI service                                             |
 | ingress.ui.path                           | Yes      | URL path for UI service (default: "/")                                 |
 | ingress.ui.pathType                       | Yes      | Path matching type: "Prefix", "Exact", or "ImplementationSpecific"     |
 | ingress.ui.ingressClassName               | No       | Ingress class name (e.g., "nginx", "gce")                             |
@@ -406,6 +407,7 @@ Once you have completed the above steps you can complete the file values.yaml to
 | ingress.ui.annotations                    | No       | Custom annotations for UI ingress                                       |
 | ingress.api.enabled                       | Yes      | Enable API ingress (default: true)                                     |
 | ingress.api.domain                        | Yes      | Domain name for API service                                            |
+| ingress.ui.port                           | No       | Custom port for API service                                            |
 | ingress.api.path                          | Yes      | URL path for API service (default: "/")                                |
 | ingress.api.pathType                      | Yes      | Path matching type: "Prefix", "Exact", or "ImplementationSpecific"     |
 | ingress.api.ingressClassName              | No       | Ingress class name (e.g., "nginx", "gce")                             |
@@ -414,6 +416,7 @@ Once you have completed the above steps you can complete the file values.yaml to
 | ingress.api.annotations                   | No       | Custom annotations for API ingress                                      |
 | ingress.registry.enabled                  | Yes      | Enable Registry ingress (default: true)                               |
 | ingress.registry.domain                   | Yes      | Domain name for Registry service                                       |
+| ingress.registry.port                     | No       | Custom port for Registry service                                       |
 | ingress.registry.path                     | Yes      | URL path for Registry service (default: "/")                           |
 | ingress.registry.pathType                 | Yes      | Path matching type: "Prefix", "Exact", or "ImplementationSpecific"     |
 | ingress.registry.ingressClassName         | No       | Ingress class name (e.g., "nginx", "gce")                             |
@@ -757,7 +760,7 @@ api:
     enabled: true
     metrics:
       port: 8081
-      host: 
+      host:
     traces:
       type: jaeger # or zipkin
       endpoint: http://jaeger-collector:14268/api/traces
@@ -772,7 +775,7 @@ executor:
     enabled: true
     metrics:
       port: 8081
-      host: 
+      host:
     traces:
       type: zupkin # or jaeger
       endpoint: zipkin:9411/api/v2/spans
@@ -786,7 +789,7 @@ registry:
     enabled: false # or true
     metrics:
       port: 8081
-      host: 
+      host:
     traces:
       type: zupkin # or jaeger
       endpoint: zipkin:9411/api/v2/spans

--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.7.6
+version: 4.7.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/templates/configMap-api.yaml
+++ b/charts/terrakube/templates/configMap-api.yaml
@@ -15,7 +15,7 @@ data:
   TerrakubeHostname: '{{ .Values.ingress.api.domain }}'
   AzBuilderExecutorUrl: '{{ .Values.api.properties.executorUrl }}/api/v1/terraform-rs'
   ExecutorReplicas: '{{ .Values.api.properties.executorReplicaCount |  default .Values.executor.replicaCount }}'
-  TerrakubeUiURL: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.ui.domain }}'
+  TerrakubeUiURL: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.ui.domain }}{{- if .Values.ingress.ui.port }}:{{ .Values.ingress.ui.port }}{{- end }}'
   TERRAKUBE_ADMIN_GROUP: '{{ .Values.security.adminGroup }}'
   TerrakubeRedisPort: '{{ .Values.api.properties.redisPort }}'
   DynamicCredentialPublicKeyPath: '{{ .Values.api.dynamicCredentials.publicKeyPath }}'

--- a/charts/terrakube/templates/configMap-executor.yaml
+++ b/charts/terrakube/templates/configMap-executor.yaml
@@ -15,7 +15,7 @@ data:
   TerrakubeToolsBranch: '{{ .Values.executor.properties.toolsBranch }}'
   TerrakubeEnableSecurity: 'true'
   TerrakubeRegistryDomain: '{{ .Values.ingress.registry.domain }}'
-  TerrakubeApiUrl: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.api.domain }}'
+  TerrakubeApiUrl: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.api.domain }}{{- if .Values.ingress.api.port }}:{{ .Values.ingress.api.port }}{{- end }}'
   TerrakubeRedisPort: '{{ .Values.api.properties.redisPort }}'
   {{- if .Values.api.defaultRedis }}
   #Default Valkey

--- a/charts/terrakube/templates/configMap-registry.yaml
+++ b/charts/terrakube/templates/configMap-registry.yaml
@@ -11,7 +11,7 @@ data:
   AuthenticationValidationTypeRegistry: 'DEX'
   DexIssuerUri: '{{ .Values.dex.config.issuer }}'
   TerrakubeEnableSecurity: 'true'
-  TerrakubeUiURL: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.ui.domain }}'
+  TerrakubeUiURL: '{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.ui.domain }}{{- if .Values.ingress.ui.port }}:{{ .Values.ingress.ui.port }}{{- end }}'
   AppIssuerUri: '{{ .Values.dex.config.issuer }}'
 
   {{- if .Values.storage.defaultStorage }}

--- a/charts/terrakube/templates/secrets-ui.yaml
+++ b/charts/terrakube/templates/secrets-ui.yaml
@@ -10,11 +10,11 @@ stringData:
   # This UI configuration file is loaded in /app/env-config.js
   env-config.js: |
     window._env_ = {
-      REACT_APP_TERRAKUBE_API_URL: "{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.api.domain }}/api/v1/",
+      REACT_APP_TERRAKUBE_API_URL: "{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.api.domain }}{{- if .Values.ingress.api.port }}:{{ .Values.ingress.api.port }}{{- end }}/api/v1/",
       REACT_APP_CLIENT_ID: "{{ .Values.security.dexClientId }}",
       REACT_APP_AUTHORITY: "{{ .Values.dex.config.issuer }}",
-      REACT_APP_REDIRECT_URI: "{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.ui.domain }}",
-      REACT_APP_REGISTRY_URI: "{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.registry.domain }}",
+      REACT_APP_REDIRECT_URI: "{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.ui.domain }}{{- if .Values.ingress.ui.port }}:{{ .Values.ingress.ui.port }}{{- end }}",
+      REACT_APP_REGISTRY_URI: "{{- if .Values.ingress.useTls }}https{{else}}http{{ end }}://{{ .Values.ingress.registry.domain }}{{- if .Values.ingress.registry.port }}:{{ .Values.ingress.registry.port }}{{- end }}",
       REACT_APP_SCOPE: "{{ .Values.security.dexClientScope }}",
       REACT_APP_TERRAKUBE_VERSION: "{{ default .Chart.AppVersion .Values.ui.version }}",
     }

--- a/charts/terrakube/values.schema.json
+++ b/charts/terrakube/values.schema.json
@@ -665,6 +665,9 @@
                         "domain": {
                             "type": "string"
                         },
+                        "port": {
+                            "type": "integer"
+                        },
                         "enabled": {
                             "type": "boolean"
                         },
@@ -953,6 +956,9 @@
                         "domain": {
                             "type": "string"
                         },
+                        "port": {
+                            "type": "integer"
+                        },
                         "enabled": {
                             "type": "boolean"
                         },
@@ -986,6 +992,9 @@
                         },
                         "domain": {
                             "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
                         },
                         "enabled": {
                             "type": "boolean"


### PR DESCRIPTION
Some company restrict the use of the port 443 to expose services.
Nevertheless, to be able to deploy Terrakube, this pull request add the possibility to expose the services (UI, API, Registry and Executor) on a custom port.