### PR TITLE
feat(api): expose CustomReleaseCacheExpirationMinutes

### DIFF
--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.7.7
+version: 4.7.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/templates/configMap-api.yaml
+++ b/charts/terrakube/templates/configMap-api.yaml
@@ -96,6 +96,7 @@ data:
   #Custom terraform releases url
   CustomTerraformReleasesUrl : '{{ .Values.api.terraformReleasesUrl }}'
   CustomTofuReleasesUrl : '{{ .Values.api.tofuReleasesUrl }}'
+  CustomReleaseCacheExpirationMinutes: '{{ .Values.api.cache.releaseCacheExpirationMinutes | default 30 }}'
   ModuleCacheMaxTotal: '{{ .Values.api.cache.moduleCacheMaxTotal }}'
   ModuleCacheMaxIdle: '{{ .Values.api.cache.moduleCacheMaxIdle }}'
   ModuleCacheMinIdle: '{{ .Values.api.cache.moduleCacheMinIdle }}'

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -265,6 +265,9 @@ api:
     moduleCacheMinIdle: "64"
     moduleCacheTimeout: "600000"
     moduleCacheSchedule: "0 */3 * ? * *"
+    # Minutes the terraform/tofu release lists are cached in Redis.
+    # Every expiration triggers one outbound call per API replica.
+    releaseCacheExpirationMinutes: "30"
   properties:
     databaseType: "POSTGRESQL"
     databaseHostname: ""


### PR DESCRIPTION
## What

Exposes `CustomReleaseCacheExpirationMinutes` through `api.cache.releaseCacheExpirationMinutes`, so operators can tune how often the API refreshes the terraform/tofu release lists.

The API **already reads this variable** — it just was never exposed by the chart:

```properties
io.terrakube.terraform.json.cacheExpirationMinutes=${CustomReleaseCacheExpirationMinutes:30}
io.terrakube.tofu.json.cacheExpirationMinutes=${CustomReleaseCacheExpirationMinutes:30}
```

## Why

At the 30-minute default, every API replica calls the releases endpoint twice an hour. That interacts badly with a bug in `DownloadReleasesService`:

```java
@Service                                        // singleton
public class DownloadReleasesService {
    private WebClient.Builder webClientBuilder;  // injected once, mutable

    public void downloadReleasesToFile(...) {
        WebClient webClient = webClientBuilder
            .defaultHeaders(h -> h.add("User-Agent", "releases-downloader"))
            .build();
```

`DefaultWebClientBuilder.defaultHeaders()` applies the consumer **immediately** to the builder's internal `HttpHeaders`. Since the builder is a field on a singleton bean and is reused on every call, each invocation appends *one more* `User-Agent` value. (`setAccept()` uses `set()` and is fine — only `add()` leaks.)

Measured against `api.github.com` from an affected cluster:

| `User-Agent` size | GitHub response |
|---|---|
| ≤ 6800 bytes | 200 |
| 7200–7600 bytes | 500 |
| ≥ 8000 bytes | 400 |

Once past the threshold, `/tofu/index.json` returns 500, and executors get `tofuReleases == null` in `TerraformDownloader`. On releases before 2.33.0-beta.7 the resulting NPE escapes the `@Async ExecutorJobImpl.createJob()` uncaught, `SimpleAsyncUncaughtExceptionHandler` only logs it, and **the job is left stuck in "running" forever** — which is exactly what we hit in production on 2.31.3, with the k8s Job reporting `Completed`.

Note this also affects workspaces that use Terraform rather than OpenTofu, since `TerraformDownloader`'s constructor fetches both release lists unconditionally.

Raising the cache window is a practical mitigation (1440 = one call/day/replica) until the header bug itself is fixed. I'll open a separate PR against `terrakube-io/terrakube` for the actual fix.

## Compatibility

- Defaults to `"30"`, so existing installs keep their current behaviour.
- The template uses `| default 30`, so values files that don't set the key still render a valid value.
- Chart version bumped 4.7.7 → 4.7.8.

Rendered output with and without the key set:

```
# api.cache.releaseCacheExpirationMinutes: "1440"
CustomReleaseCacheExpirationMinutes: '1440'

# key absent
CustomReleaseCacheExpirationMinutes: '30'
```